### PR TITLE
feat: update delegation dependency and simplify usage

### DIFF
--- a/.github/workflows/publish-crates-and-sdk.yml
+++ b/.github/workflows/publish-crates-and-sdk.yml
@@ -92,6 +92,7 @@ jobs:
             NO_VERIFY_FLAG="--no-verify"
           fi      
 
+          cargo publish $DRY_RUN_FLAG --manifest-path=sdk/ephemeral/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
           cargo publish $DRY_RUN_FLAG --manifest-path=sdk/delegate/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
           cargo publish $DRY_RUN_FLAG --manifest-path=sdk/commit_attribute/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
           cargo publish $DRY_RUN_FLAG --manifest-path=sdk/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,33 +746,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "ephemeral-rollups-sdk"
-version = "0.0.7"
+name = "ephemeral-rollups-sdk-attribute-commit-v2"
+version = "0.1.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk-attribute-delegate-v2"
+version = "0.1.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk-attribute-ephemeral-v2"
+version = "0.1.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk-v2"
+version = "0.1.1"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.3",
- "ephemeral-rollups-sdk-attribute-commit",
- "ephemeral-rollups-sdk-attribute-delegate",
+ "ephemeral-rollups-sdk-attribute-commit-v2",
+ "ephemeral-rollups-sdk-attribute-delegate-v2",
+ "ephemeral-rollups-sdk-attribute-ephemeral-v2",
  "paste",
  "solana-program",
-]
-
-[[package]]
-name = "ephemeral-rollups-sdk-attribute-commit"
-version = "0.0.7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.0.7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.7"
+version = "0.1.1"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 edition = "2021"
 license = "MIT"
@@ -17,8 +17,9 @@ readme = "./README.md"
 keywords = ["solana", "crypto", "delegation", "ephemeral-rollups", "magicblock"]
 
 [workspace.dependencies]
-ephemeral-rollups-sdk-attribute-delegate = { path = "sdk/delegate", version = "=0.0.7" }
-ephemeral-rollups-sdk-attribute-commit = { path = "sdk/commit_attribute", version = "=0.0.7" }
+ephemeral-rollups-sdk-attribute-ephemeral-v2 = { path = "sdk/ephemeral", version = "=0.1.1" }
+ephemeral-rollups-sdk-attribute-delegate-v2 = { path = "sdk/delegate", version = "=0.1.1" }
+ephemeral-rollups-sdk-attribute-commit-v2 = { path = "sdk/commit_attribute", version = "=0.1.1" }
 
 ## External crates
 anchor-lang = "0.30.1"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ephemeral-rollups-sdk"
+name = "ephemeral-rollups-sdk-v2"
 description = "Ephemeral Rollups Integration SDK"
 version = { workspace = true }
 authors = { workspace = true }
@@ -17,8 +17,9 @@ anchor = ["anchor-lang"]
 
 [dependencies]
 borsh = { workspace = true }
-ephemeral-rollups-sdk-attribute-delegate = { workspace = true }
-ephemeral-rollups-sdk-attribute-commit = { workspace = true }
+ephemeral-rollups-sdk-attribute-delegate-v2 = { workspace = true }
+ephemeral-rollups-sdk-attribute-ephemeral-v2 = { workspace = true }
+ephemeral-rollups-sdk-attribute-commit-v2 = { workspace = true }
 paste = { workspace = true }
 solana-program = { workspace = true }
 anchor-lang = { workspace = true, optional = true }

--- a/sdk/commit_attribute/Cargo.toml
+++ b/sdk/commit_attribute/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ephemeral-rollups-sdk-attribute-commit"
+name = "ephemeral-rollups-sdk-attribute-commit-v2"
 description = "ephemeral-rollups-sdk-attribute-commit"
 version = { workspace = true }
 authors = { workspace = true }

--- a/sdk/commit_attribute/src/lib.rs
+++ b/sdk/commit_attribute/src/lib.rs
@@ -9,52 +9,56 @@ pub fn commit(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemStruct);
 
     let name = &input.ident;
-    let expanded =
-        if let Fields::Named(fields_named) = &input.fields {
-            let mut has_magic_program = false;
-            let mut has_magic_context = false;
+    let attrs = &input.attrs; // Capture all attributes
+    let expanded = if let Fields::Named(fields_named) = &input.fields {
+        let mut has_magic_program = false;
+        let mut has_magic_context = false;
 
-            for field in &fields_named.named {
-                if let Some(ident) = &field.ident {
-                    if ident == "magic_program" {
-                        has_magic_program = true;
-                    } else if ident == "magic_context" {
-                        has_magic_context = true;
-                    }
+        for field in &fields_named.named {
+            if let Some(ident) = &field.ident {
+                if ident == "magic_program" {
+                    has_magic_program = true;
+                } else if ident == "magic_context" {
+                    has_magic_context = true;
                 }
             }
+        }
 
-            let mut new_fields = fields_named.named.clone();
+        let mut new_fields = fields_named.named.clone();
 
-            if !has_magic_program {
-                new_fields.push(
+        if !has_magic_program {
+            new_fields.push(
                     Field::parse_named
                         .parse2(quote! {
-                            pub magic_program: Program<'info, MagicProgram>
+                            pub magic_program: Program<'info, ::ephemeral_rollups_sdk_v2::anchor::MagicProgram>
                         })
                         .unwrap(),
                 );
-            }
+        }
 
-            if !has_magic_context {
-                new_fields.push(Field::parse_named.parse2(quote! {
-                #[account(mut, address = ephemeral_rollups_sdk::consts::MAGIC_CONTEXT_ID)]
-                /// CHECK:`
-                pub magic_context: AccountInfo<'info>
-            }).unwrap());
-            }
+        if !has_magic_context {
+            new_fields.push(
+                Field::parse_named
+                    .parse2(quote! {
+                        #[account(mut, address = ::ephemeral_rollups_sdk_v2::consts::MAGIC_CONTEXT_ID)]
+                        /// CHECK:`
+                        pub magic_context: AccountInfo<'info>
+                    })
+                    .unwrap(),
+            );
+        }
 
-            quote! {
-                #[derive(Accounts)]
-                pub struct #name<'info> {
-                    #new_fields
-                }
+        quote! {
+            #(#attrs)*
+            pub struct #name<'info> {
+                #new_fields
             }
-        } else {
-            quote! {
-                compile_error!("Commit attribute can only be used with structs with named fields");
-            }
-        };
+        }
+    } else {
+        quote! {
+            compile_error!("Commit attribute can only be used with structs with named fields");
+        }
+    };
 
     TokenStream::from(expanded)
 }

--- a/sdk/ephemeral/Cargo.toml
+++ b/sdk/ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "ephemeral-rollups-sdk-attribute-delegate-v2"
-description = "ephemeral-rollups-sdk-attribute-delegate"
+name = "ephemeral-rollups-sdk-attribute-ephemeral-v2"
+description = "ephemeral-rollups-sdk-attribute-ephemeral"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/sdk/ephemeral/src/lib.rs
+++ b/sdk/ephemeral/src/lib.rs
@@ -1,0 +1,139 @@
+use proc_macro::TokenStream;
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{parse_macro_input, ItemMod};
+
+/// This macro attribute is used to inject instructions and struct needed from the delegation program.
+///
+/// Components can be delegate and undelegated to allow fast udpates in the Ephemeral Rollups.
+///
+/// # Example
+/// ```ignore
+///
+/// pub fn delegate(ctx: Context<DelegateInput>) -> Result<()> {
+///     let pda_seeds: &[&[u8]] = &[TEST_PDA_SEED];
+///
+///     let [payer, pda, owner_program, buffer, delegation_record, delegation_metadata, delegation_program, system_program] = [
+///         &ctx.accounts.payer,
+///         &ctx.accounts.pda,
+///         &ctx.accounts.owner_program,
+///         &ctx.accounts.buffer,
+///         &ctx.accounts.buffer,
+///         &ctx.accounts.delegation_record,
+///         &ctx.accounts.delegation_metadata,
+///         &ctx.accounts.delegation_program,
+///         &ctx.accounts.system_program,
+///     ];
+///
+///     delegate_account(
+///         payer,
+///         pda,
+///         owner_program,
+///         buffer,
+///         delegation_record,
+///         delegation_metadata,
+///         delegation_program,
+///         system_program,
+///         pda_seeds,
+///         0,
+///         30000
+///     )?;
+///
+///     Ok(())
+/// }
+///
+/// #[derive(Accounts)]
+/// pub struct DelegateInput<'info> {
+///     pub payer: Signer<'info>,
+///     /// CHECK: The pda to delegate
+///     #[account(mut)]
+///     pub pda: AccountInfo<'info>,
+///     /// CHECK: The owner program of the pda
+///     pub owner_program: AccountInfo<'info>,
+///     /// CHECK: The buffer to temporarily store the pda data
+///     #[account(mut)]
+///     pub buffer: AccountInfo<'info>,
+///     /// CHECK: The delegation record
+///     #[account(mut)]
+///     pub delegation_record: AccountInfo<'info>,
+///     /// CHECK: The delegation account seeds
+///     #[account(mut)]
+///     pub delegation_metadata: AccountInfo<'info>,
+///     /// CHECK: The delegation program
+///     pub delegation_program: AccountInfo<'info>,
+///     /// CHECK: The system program
+///     pub system_program: AccountInfo<'info>,
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn ephemeral(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as syn::ItemMod);
+    let modified = modify_component_module(ast);
+    TokenStream::from(quote! {
+        #modified
+    })
+}
+
+/// Modifies the component module and adds the necessary functions and structs.
+fn modify_component_module(mut module: ItemMod) -> ItemMod {
+    let (imports, undelegate_fn, undelegate_struct) = generate_undelegate();
+    module.content = module.content.map(|(brace, mut items)| {
+        items.extend(
+            vec![imports, undelegate_fn, undelegate_struct]
+                .into_iter()
+                .map(|item| {
+                    syn::parse2(item).unwrap_or_else(|e| panic!("Failed to parse item: {}", e))
+                })
+                .collect::<Vec<_>>(),
+        );
+        (brace, items)
+    });
+    module
+}
+
+/// Generates the undelegate function and struct.
+fn generate_undelegate() -> (TokenStream2, TokenStream2, TokenStream2) {
+    (
+        quote! {
+            use ephemeral_rollups_sdk_v2::cpi::undelegate_account;
+        },
+        quote! {
+            #[automatically_derived]
+            pub fn process_undelegation(ctx: Context<InitializeAfterUndelegation>, account_seeds: Vec<Vec<u8>>) -> Result<()> {
+                let [delegated_account, buffer, payer, system_program] = [
+                    &ctx.accounts.base_account,
+                    &ctx.accounts.buffer,
+                    &ctx.accounts.payer,
+                    &ctx.accounts.system_program,
+                ];
+                undelegate_account(
+                    delegated_account,
+                    &id(),
+                    buffer,
+                    payer,
+                    system_program,
+                    account_seeds,
+                )?;
+                Ok(())
+            }
+        },
+        quote! {
+            #[automatically_derived]
+            #[derive(Accounts)]
+                pub struct InitializeAfterUndelegation<'info> {
+                /// CHECK:`
+                #[account(mut)]
+                pub base_account: AccountInfo<'info>,
+                /// CHECK:`
+                #[account()]
+                pub buffer: AccountInfo<'info>,
+                /// CHECK:`
+                #[account(mut)]
+                pub payer: AccountInfo<'info>,
+                /// CHECK:`
+                pub system_program: AccountInfo<'info>,
+            }
+        },
+    )
+}

--- a/sdk/src/anchor.rs
+++ b/sdk/src/anchor.rs
@@ -1,8 +1,11 @@
 #[cfg(feature = "anchor")]
-pub use ephemeral_rollups_sdk_attribute_delegate::delegate;
+pub use ephemeral_rollups_sdk_attribute_ephemeral_v2::ephemeral;
 
 #[cfg(feature = "anchor")]
-pub use ephemeral_rollups_sdk_attribute_commit::commit;
+pub use ephemeral_rollups_sdk_attribute_commit_v2::commit;
+
+#[cfg(feature = "anchor")]
+pub use ephemeral_rollups_sdk_attribute_delegate_v2::delegate;
 
 #[cfg(feature = "anchor")]
 use solana_program::pubkey::Pubkey;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,7 +1,5 @@
 use solana_program::pubkey::Pubkey;
-
-pub use ephemeral_rollups_sdk_attribute_delegate::delegate;
-
+#[cfg(feature = "anchor")]
 pub mod anchor;
 pub mod consts;
 pub mod cpi;

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -1,8 +1,21 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct DelegateAccountArgs {
     pub valid_until: i64,
     pub commit_frequency_ms: u32,
     pub seeds: Vec<Vec<u8>>,
+    pub validator: Option<Pubkey>,
+}
+
+impl Default for DelegateAccountArgs {
+    fn default() -> Self {
+        DelegateAccountArgs {
+            valid_until: 0,
+            commit_frequency_ms: u32::MAX,
+            seeds: vec![],
+            validator: None,
+        }
+    }
 }

--- a/sdk/src/utils.rs
+++ b/sdk/src/utils.rs
@@ -93,6 +93,33 @@ pub fn close_pda<'a, 'info>(
     target_account.realloc(0, false).map_err(Into::into)
 }
 
+/// Close PDA with transfer
+#[inline(always)]
+pub fn close_pda_with_system_transfer<'a, 'info>(
+    target_account: &'a AccountInfo<'info>,
+    seeds: &[&[&[u8]]],
+    destination: &'a AccountInfo<'info>,
+    system_program: &'a AccountInfo<'info>,
+) -> ProgramResult {
+    let transfer_instruction = solana_program::system_instruction::transfer(
+        target_account.key,
+        destination.key,
+        target_account.lamports(),
+    );
+    target_account.realloc(0, true)?;
+    target_account.assign(&solana_program::system_program::ID);
+    solana_program::program::invoke_signed(
+        &transfer_instruction,
+        &[
+            target_account.clone(),
+            destination.clone(),
+            system_program.clone(),
+        ],
+        seeds,
+    )?;
+    Ok(())
+}
+
 /// Seeds with bump
 #[inline(always)]
 pub fn seeds_with_bump<'a>(seeds: &'a [&'a [u8]], bump: &'a [u8]) -> Vec<&'a [u8]> {

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@magicblock-labs/ephemeral-rollups-sdk",
-  "version": "0.0.7",
+  "name": "@magicblock-labs/ephemeral-rollups-sdk-v2",
+  "version": "0.1.1",
   "author": "MagicBlock Labs",
   "license": "MIT",
   "publishConfig": {
@@ -37,5 +37,6 @@
   "dependencies": {
     "@metaplex-foundation/beet": "^0.7.2",
     "@solana/web3.js": "^1.92.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/sdk/ts/src/instructions/delegate.ts
+++ b/sdk/ts/src/instructions/delegate.ts
@@ -9,16 +9,17 @@ export const delegateStruct = new beet.FixableBeetArgsStruct<{
   valid_until: beet.bignum;
   commit_frequency_ms: beet.bignum;
   seeds: number[][];
+  validator?: beet.COption<Uint8Array>;
 }>(
   [
     ["instructionDiscriminator", beet.uniformFixedSizeArray(beet.u8, 8)],
     ["valid_until", beet.i64],
     ["commit_frequency_ms", beet.u32],
     ["seeds", beet.array(beet.array(beet.u8))],
+    ["validator", beet.coption(beet.uniformFixedSizeArray(beet.u8, 32))],
   ],
   "UndelegateInstructionArgs",
 );
-
 export const delegateInstructionDiscriminator = [0, 0, 0, 0, 0, 0, 0, 0];
 
 // Define the DelegateAccountArgs structure
@@ -26,8 +27,8 @@ interface DelegateAccountArgs {
   valid_until: number;
   commit_frequency_ms: number;
   seeds: Uint8Array[][];
+  validator?: web3.PublicKey;
 }
-
 // Function to create a delegate instruction
 export function createDelegateInstruction(
   accounts: {
@@ -51,6 +52,7 @@ export function createDelegateInstruction(
     valid_until: 0,
     commit_frequency_ms: 4294967295, // 2 ** 4 - 1,
     seeds: [],
+    validator: undefined,
   };
 
   const keys: web3.AccountMeta[] = [
@@ -84,6 +86,7 @@ export function createDelegateInstruction(
     valid_until: args.valid_until,
     commit_frequency_ms: args.commit_frequency_ms,
     seeds: args.seeds.map((seed) => seed.map(Number)),
+    validator: args.validator ? args.validator.toBytes() : undefined,
   });
 
   return new web3.TransactionInstruction({

--- a/sdk/ts/src/instructions/undelegate.ts
+++ b/sdk/ts/src/instructions/undelegate.ts
@@ -16,7 +16,7 @@ export const undelegateStruct = new beet.FixableBeetArgsStruct<{
  */
 
 export interface UndelegateInstructionAccounts {
-  payer: web3.PublicKey;
+  validator: web3.PublicKey;
   delegatedAccount: web3.PublicKey;
   ownerProgram: web3.PublicKey;
   buffer?: web3.PublicKey;
@@ -51,9 +51,19 @@ export function createUndelegateInstruction(
     commitStatePda,
   } = UndelegateAccounts(accounts.delegatedAccount, accounts.ownerProgram);
 
+  const validatorFeesVaultPda = web3.PublicKey.findProgramAddressSync(
+    [Buffer.from("v-fees-vault"), accounts.validator.toBuffer()],
+    programId,
+  )[0];
+
+  const feesVaultPda = web3.PublicKey.findProgramAddressSync(
+    [Buffer.from("fees-vault")],
+    programId,
+  )[0];
+
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: accounts.payer,
+      pubkey: accounts.validator,
       isWritable: false,
       isSigner: true,
     },
@@ -96,6 +106,16 @@ export function createUndelegateInstruction(
       pubkey: accounts.reimbursement,
       isWritable: false,
       isSigner: false,
+    },
+    {
+      pubkey: feesVaultPda,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: validatorFeesVaultPda,
+      isSigner: false,
+      isWritable: true,
     },
     {
       pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,

--- a/sdk/ts/yarn.lock
+++ b/sdk/ts/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.25.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
@@ -60,7 +67,17 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@metaplex-foundation/beet@^0.7.2":
+"@metaplex-foundation/beet-solana@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet-solana/-/beet-solana-0.4.1.tgz#255747aa7feee1c20202146a752c057feca1948f"
+  integrity sha512-/6o32FNUtwK8tjhotrvU/vorP7umBuRFvBZrC6XCk51aKidBHe5LPVPA5AjGPbV3oftMfRuXPNd9yAGeEqeCDQ==
+  dependencies:
+    "@metaplex-foundation/beet" ">=0.1.0"
+    "@solana/web3.js" "^1.56.2"
+    bs58 "^5.0.0"
+    debug "^4.3.4"
+
+"@metaplex-foundation/beet@>=0.1.0", "@metaplex-foundation/beet@^0.7.2":
   version "0.7.2"
   resolved "https://registry.npmjs.org/@metaplex-foundation/beet/-/beet-0.7.2.tgz"
   integrity sha512-K+g3WhyFxKPc0xIvcIjNyV1eaTVJTiuaHZpig7Xx0MuYRMoJLLvhLTnUXhFdR5Tu2l2QSyKwfyXDgZlzhULqFg==
@@ -77,10 +94,22 @@
   dependencies:
     "@noble/hashes" "1.4.0"
 
-"@noble/hashes@^1.4.0", "@noble/hashes@1.4.0":
+"@noble/curves@^1.4.2":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.7.0.tgz#0512360622439256df892f21d25b388f52505e45"
+  integrity sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==
+  dependencies:
+    "@noble/hashes" "1.6.0"
+
+"@noble/hashes@1.4.0", "@noble/hashes@^1.4.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz"
   integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
+"@noble/hashes@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.0.tgz#d4bfb516ad6e7b5111c216a5cc7075f4cf19e6c5"
+  integrity sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -90,7 +119,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -115,6 +144,27 @@
   dependencies:
     buffer "~6.0.3"
 
+"@solana/web3.js@^1.56.2":
+  version "1.95.5"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.95.5.tgz#ba70da4c205c64249ed94369fe2d617c0347cd85"
+  integrity sha512-hU9cBrbg1z6gEjLH9vwIckGBVB78Ijm0iZFNk4ocm5OD82piPwuk3MeQ1rfiKD9YQtr95krrcaopb49EmQJlRg==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    "@noble/curves" "^1.4.2"
+    "@noble/hashes" "^1.4.0"
+    "@solana/buffer-layout" "^4.0.1"
+    agentkeepalive "^4.5.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.2.1"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.3"
+    fast-stable-stringify "^1.0.0"
+    jayson "^4.1.1"
+    node-fetch "^2.7.0"
+    rpc-websockets "^9.0.2"
+    superstruct "^2.0.2"
+
 "@solana/web3.js@^1.92.3":
   version "1.92.3"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.92.3.tgz"
@@ -136,6 +186,13 @@
     rpc-websockets "^8.0.1"
     superstruct "^1.0.4"
 
+"@swc/helpers@^0.5.11":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
+  integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
+  dependencies:
+    tslib "^2.8.0"
+
 "@types/connect@^3.4.33":
   version "3.4.38"
   resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz"
@@ -153,10 +210,22 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/ws@^7.4.4":
   version "7.4.7"
   resolved "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz"
   integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^8.2.2":
+  version "8.5.13"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.13.tgz#6414c280875e2691d0d1e080b05addbf5cb91e20"
+  integrity sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==
   dependencies:
     "@types/node" "*"
 
@@ -280,6 +349,14 @@
   version "1.2.0"
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -431,6 +508,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
@@ -493,7 +575,14 @@ bs58@^4.0.0, bs58@^4.0.1:
   dependencies:
     base-x "^3.0.2"
 
-buffer@~6.0.3, buffer@6.0.3:
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
+
+buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -969,6 +1058,11 @@ eventemitter3@^4.0.7:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 eyes@^0.1.8:
   version "0.1.8"
   resolved "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
@@ -1283,7 +1377,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1469,15 +1563,33 @@ jayson@^4.1.0:
     "@types/connect" "^3.4.33"
     "@types/node" "^12.12.54"
     "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
     commander "^2.20.3"
     delay "^5.0.0"
     es6-promisify "^5.0.0"
     eyes "^0.1.8"
     isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
-    JSONStream "^1.3.5"
     uuid "^8.3.2"
     ws "^7.4.5"
+
+jayson@^4.1.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-4.1.3.tgz#db9be2e4287d9fef4fc05b5fe367abe792c2eee8"
+  integrity sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==
+  dependencies:
+    "@types/connect" "^3.4.33"
+    "@types/node" "^12.12.54"
+    "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
+    commander "^2.20.3"
+    delay "^5.0.0"
+    es6-promisify "^5.0.0"
+    eyes "^0.1.8"
+    isomorphic-ws "^4.0.1"
+    json-stringify-safe "^5.0.1"
+    uuid "^8.3.2"
+    ws "^7.5.10"
 
 js-yaml@^4.1.0:
   version "4.1.0"
@@ -1522,14 +1634,6 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
-
-JSONStream@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
 
 keyv@^4.5.3:
   version "4.5.4"
@@ -1581,19 +1685,19 @@ micromatch@^4.0.4:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+minimatch@9.0.3, minimatch@^9.0.0:
+  version "9.0.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.0, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^9.0.0:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
 
 minimatch@^9.0.4:
   version "9.0.4"
@@ -1602,19 +1706,12 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-ms@^2.0.0, ms@^2.1.1, ms@2.1.2:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -1862,6 +1959,22 @@ rpc-websockets@^8.0.1:
     bufferutil "^4.0.1"
     utf-8-validate "^5.0.2"
 
+rpc-websockets@^9.0.2:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-9.0.4.tgz#9d8ee82533b5d1e13d9ded729e3e38d0d8fa083f"
+  integrity sha512-yWZWN0M+bivtoNLnaDbtny4XchdAIF5Q4g/ZsC5UC61Ckbp0QczwO8fg44rV3uYmY4WHd+EZQbn90W1d8ojzqQ==
+  dependencies:
+    "@swc/helpers" "^0.5.11"
+    "@types/uuid" "^8.3.4"
+    "@types/ws" "^8.2.2"
+    buffer "^6.0.3"
+    eventemitter3 "^5.0.1"
+    uuid "^8.3.2"
+    ws "^8.5.0"
+  optionalDependencies:
+    bufferutil "^4.0.1"
+    utf-8-validate "^5.0.2"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
@@ -2016,6 +2129,11 @@ superstruct@^1.0.4:
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz"
   integrity sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==
 
+superstruct@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-2.0.2.tgz#3f6d32fbdc11c357deff127d591a39b996300c54"
+  integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
@@ -2087,6 +2205,11 @@ tslib@^2.6.2:
   version "2.6.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
+tslib@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2284,6 +2407,11 @@ ws@^7.4.5:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^7.5.10:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.5.0:
   version "8.17.0"


### PR DESCRIPTION
## feat: update delegation dependency and simplify usage

- Update delegation program dependency
- Simplify usage and delegation API
- Introduced Anchor helpers

## Notes

- Since this is a breaking version and the delegation program has not yet been deployed, the crate is temporarily published at `ephemeral-rollups-sdk-v2`

- Similarly, the ts sdk is published at `@magicblock-labs/ephemeral-rollups-sdk-v2`

## Issues

Closes #6 