### PR TITLE
Remove upper bound constraint for solana and anchor dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,7 +27,7 @@ ephemeral-rollups-sdk-attribute-delegate = { path = "delegate", version = "=0.2.
 ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = "=0.2.3" }
 
 ## External crates
-anchor-lang = { version = ">=0.28.0, <=0.30.1" }
+anchor-lang = { version = ">=0.28.0" }
 borsh = "0.10.3"
 paste = "^1.0"
 proc-macro2 = "1.0"
@@ -44,10 +44,10 @@ websocket = { package = "tokio-websockets", version = "0.10", features = [ "clie
 reqwest = { version = "0.12" }
 
 # solana
-solana-program = { version = ">=1.16, <=2.1.11" }
-sdk = { package = "solana-sdk", version = ">=1.16, <=2.1.11" }
-rpc = { package = "solana-rpc-client", version = ">=1.16, <=2.1.11" }
-rpc-api = { package = "solana-rpc-client-api", version = ">=1.16, <=2.1.11" }
+solana-program = { version = ">=1.16" }
+sdk = { package = "solana-sdk", version = ">=1.16" }
+rpc = { package = "solana-rpc-client", version = ">=1.16" }
+rpc-api = { package = "solana-rpc-client-api", version = ">=1.16" }
 
 # parsing
 serde = { version = "1.0", features = [ "derive" ] }


### PR DESCRIPTION
Remove upper bound constraint for solana and anchor dependency with the new release of anchor 0.31.0 which allows the usage of solana program 2 and above.