### PR TITLE
Refactor: Replace PDA seed macros with Seed enum API

### DIFF
--- a/rust/pinocchio/src/lib.rs
+++ b/rust/pinocchio/src/lib.rs
@@ -5,5 +5,6 @@ pub mod instruction;
 pub mod pda;
 pub mod types;
 pub mod utils;
+pub mod seeds;
 
 pinocchio_pubkey::declare_id!("DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh");

--- a/rust/pinocchio/src/lib.rs
+++ b/rust/pinocchio/src/lib.rs
@@ -3,8 +3,8 @@
 pub mod consts;
 pub mod instruction;
 pub mod pda;
+pub mod seeds;
 pub mod types;
 pub mod utils;
-pub mod seeds;
 
 pinocchio_pubkey::declare_id!("DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh");

--- a/rust/pinocchio/src/pda.rs
+++ b/rust/pinocchio/src/pda.rs
@@ -1,6 +1,6 @@
+use crate::seeds::Seed;
 use pinocchio::pubkey;
 use pinocchio::pubkey::Pubkey;
-use crate::seeds::Seed;
 
 /// Generic DRY function to find a PDA from a typed `Seed`
 fn find_seed_pda(seed: &Seed, program_id: &Pubkey) -> Pubkey {

--- a/rust/pinocchio/src/pda.rs
+++ b/rust/pinocchio/src/pda.rs
@@ -4,8 +4,10 @@ use pinocchio::pubkey::Pubkey;
 
 /// Generic DRY function to find a PDA from a typed `Seed`
 fn find_seed_pda(seed: &Seed, program_id: &Pubkey) -> Pubkey {
-    let seeds = seed.as_seed_slice();
-    pubkey::find_program_address(&seeds, program_id).0
+    let mut buf: [&[u8]; 3] = [&[]; 3];
+    let mut index_buf = [0u8; 1];
+    let seeds = seed.fill_seed_slice(&mut buf, &mut index_buf);
+    pubkey::find_program_address(seeds, program_id).0
 }
 
 // Specialized functions calling the generic one

--- a/rust/pinocchio/src/pda.rs
+++ b/rust/pinocchio/src/pda.rs
@@ -1,151 +1,53 @@
 use pinocchio::pubkey;
 use pinocchio::pubkey::Pubkey;
+use crate::seeds::Seed;
 
-#[macro_export]
-macro_rules! delegation_record_seeds_from_delegated_account {
-    ($delegated_account: expr) => {
-        &[b"delegation", $delegated_account.as_ref()]
-    };
+/// Generic DRY function to find a PDA from a typed `Seed`
+fn find_seed_pda(seed: &Seed, program_id: &Pubkey) -> Pubkey {
+    let seeds = seed.as_seed_slice();
+    pubkey::find_program_address(&seeds, program_id).0
 }
 
-#[macro_export]
-macro_rules! delegation_metadata_seeds_from_delegated_account {
-    ($delegated_account: expr) => {
-        &[b"delegation-metadata", $delegated_account.as_ref()]
-    };
+// Specialized functions calling the generic one
+pub fn delegation_record_pda_from_delegated_account(delegated: &Pubkey) -> Pubkey {
+    find_seed_pda(&Seed::Delegation(delegated), &crate::id())
 }
 
-#[macro_export]
-macro_rules! commit_state_seeds_from_delegated_account {
-    ($delegated_account: expr) => {
-        &[b"state-diff", $delegated_account.as_ref()]
-    };
+pub fn delegation_metadata_pda_from_delegated_account(delegated: &Pubkey) -> Pubkey {
+    find_seed_pda(&Seed::DelegationMetadata(delegated), &crate::id())
 }
 
-#[macro_export]
-macro_rules! commit_record_seeds_from_delegated_account {
-    ($delegated_account: expr) => {
-        &[b"commit-state-record", $delegated_account.as_ref()]
-    };
+pub fn commit_state_pda_from_delegated_account(delegated: &Pubkey) -> Pubkey {
+    find_seed_pda(&Seed::CommitState(delegated), &crate::id())
 }
 
-#[macro_export]
-macro_rules! delegate_buffer_seeds_from_delegated_account {
-    ($delegated_account: expr) => {
-        &[b"buffer", $delegated_account.as_ref()]
-    };
-}
-
-#[macro_export]
-macro_rules! undelegate_buffer_seeds_from_delegated_account {
-    ($delegated_account: expr) => {
-        &[b"undelegate-buffer", $delegated_account.as_ref()]
-    };
-}
-
-#[macro_export]
-macro_rules! fees_vault_seeds {
-    () => {
-        &[b"fees-vault"]
-    };
-}
-
-#[macro_export]
-macro_rules! validator_fees_vault_seeds_from_validator {
-    ($validator: expr) => {
-        &[b"v-fees-vault", $validator.as_ref()]
-    };
-}
-
-#[macro_export]
-macro_rules! program_config_seeds_from_program_id {
-    ($program_id: expr) => {
-        &[b"p-conf", $program_id.as_ref()]
-    };
-}
-
-#[macro_export]
-macro_rules! ephemeral_balance_seeds_from_payer {
-    ($payer: expr, $index: expr) => {
-        &[b"balance", $payer.as_ref(), &[$index]]
-    };
-}
-
-pub fn delegation_record_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
-    pubkey::find_program_address(
-        delegation_record_seeds_from_delegated_account!(delegated_account),
-        &crate::id(),
-    )
-    .0
-}
-
-pub fn delegation_metadata_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
-    pubkey::find_program_address(
-        delegation_metadata_seeds_from_delegated_account!(delegated_account),
-        &crate::id(),
-    )
-    .0
-}
-
-pub fn commit_state_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
-    pubkey::find_program_address(
-        commit_state_seeds_from_delegated_account!(delegated_account),
-        &crate::id(),
-    )
-    .0
-}
-
-pub fn commit_record_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
-    pubkey::find_program_address(
-        commit_record_seeds_from_delegated_account!(delegated_account),
-        &crate::id(),
-    )
-    .0
+pub fn commit_record_pda_from_delegated_account(delegated: &Pubkey) -> Pubkey {
+    find_seed_pda(&Seed::CommitRecord(delegated), &crate::id())
 }
 
 pub fn delegate_buffer_pda_from_delegated_account_and_owner_program(
-    delegated_account: &Pubkey,
+    delegated: &Pubkey,
     owner_program: &Pubkey,
 ) -> Pubkey {
-    pubkey::find_program_address(
-        delegate_buffer_seeds_from_delegated_account!(delegated_account),
-        owner_program,
-    )
-    .0
+    find_seed_pda(&Seed::Buffer(delegated), owner_program)
 }
 
-pub fn undelegate_buffer_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
-    pubkey::find_program_address(
-        undelegate_buffer_seeds_from_delegated_account!(delegated_account),
-        &crate::id(),
-    )
-    .0
+pub fn undelegate_buffer_pda_from_delegated_account(delegated: &Pubkey) -> Pubkey {
+    find_seed_pda(&Seed::UndelegateBuffer(delegated), &crate::id())
 }
 
 pub fn fees_vault_pda() -> Pubkey {
-    pubkey::find_program_address(fees_vault_seeds!(), &crate::id()).0
+    find_seed_pda(&Seed::FeesVault, &crate::id())
 }
 
 pub fn validator_fees_vault_pda_from_validator(validator: &Pubkey) -> Pubkey {
-    pubkey::find_program_address(
-        validator_fees_vault_seeds_from_validator!(validator),
-        &crate::id(),
-    )
-    .0
+    find_seed_pda(&Seed::ValidatorFeesVault(validator), &crate::id())
 }
 
 pub fn program_config_from_program_id(program_id: &Pubkey) -> Pubkey {
-    pubkey::find_program_address(
-        program_config_seeds_from_program_id!(program_id),
-        &crate::id(),
-    )
-    .0
+    find_seed_pda(&Seed::ProgramConfig(program_id), &crate::id())
 }
 
 pub fn ephemeral_balance_pda_from_payer(payer: &Pubkey, index: u8) -> Pubkey {
-    pubkey::find_program_address(
-        ephemeral_balance_seeds_from_payer!(payer, index),
-        &crate::id(),
-    )
-    .0
+    find_seed_pda(&Seed::EphemeralBalance { payer, index }, &crate::id())
 }

--- a/rust/pinocchio/src/seeds.rs
+++ b/rust/pinocchio/src/seeds.rs
@@ -15,20 +15,65 @@ pub enum Seed<'a> {
 }
 
 impl<'a> Seed<'a> {
-    pub fn as_seed_slice(&self) -> Vec<&[u8]> {
+    pub fn fill_seed_slice<'b>(
+        &'a self,
+        out: &'b mut [&'a [u8]; 3],
+        index_buf: &'b mut [u8; 1],
+    ) -> &'b [&'a [u8]]
+    where
+        'b: 'a,
+    {
         match self {
-            Seed::Delegation(pubkey) => vec![b"delegation", pubkey.as_ref()],
-            Seed::DelegationMetadata(pubkey) => vec![b"delegation-metadata", pubkey.as_ref()],
-            Seed::Buffer(pubkey) => vec![b"buffer", pubkey.as_ref()],
-            Seed::CommitState(pubkey) => vec![b"state-diff", pubkey.as_ref()],
-            Seed::CommitRecord(pubkey) => vec![b"commit-state-record", pubkey.as_ref()],
-            Seed::UndelegateBuffer(pubkey) => vec![b"undelegate-buffer", pubkey.as_ref()],
-            Seed::ValidatorFeesVault(pubkey) => vec![b"v-fees-vault", pubkey.as_ref()],
-            Seed::ProgramConfig(program_id) => vec![b"p-conf", program_id.as_ref()],
-            Seed::FeesVault => vec![b"fees-vault"],
+            Seed::Delegation(pubkey) => {
+                out[0] = b"delegation";
+                out[1] = pubkey.as_ref();
+                &out[..2]
+            }
+            Seed::DelegationMetadata(pubkey) => {
+                out[0] = b"delegation-metadata";
+                out[1] = pubkey.as_ref();
+                &out[..2]
+            }
+            Seed::Buffer(pubkey) => {
+                out[0] = b"buffer";
+                out[1] = pubkey.as_ref();
+                &out[..2]
+            }
+            Seed::CommitState(pubkey) => {
+                out[0] = b"state-diff";
+                out[1] = pubkey.as_ref();
+                &out[..2]
+            }
+            Seed::CommitRecord(pubkey) => {
+                out[0] = b"commit-state-record";
+                out[1] = pubkey.as_ref();
+                &out[..2]
+            }
+            Seed::UndelegateBuffer(pubkey) => {
+                out[0] = b"undelegate-buffer";
+                out[1] = pubkey.as_ref();
+                &out[..2]
+            }
+            Seed::ValidatorFeesVault(pubkey) => {
+                out[0] = b"v-fees-vault";
+                out[1] = pubkey.as_ref();
+                &out[..2]
+            }
+            Seed::ProgramConfig(program_id) => {
+                out[0] = b"p-conf";
+                out[1] = program_id.as_ref();
+                &out[..2]
+            }
+            Seed::FeesVault => {
+                out[0] = b"fees-vault";
+                &out[..1]
+            }
             Seed::EphemeralBalance { payer, index } => {
-                let index_ref = std::slice::from_ref(index);
-                vec![b"balance", payer.as_ref(), index_ref]
+                out[0] = b"balance";
+                out[1] = payer.as_ref();
+                index_buf[0] = *index;
+                out[2] = &index_buf[..];
+                &out[..3]
             }
         }
     }

--- a/rust/pinocchio/src/seeds.rs
+++ b/rust/pinocchio/src/seeds.rs
@@ -1,0 +1,35 @@
+use pinocchio::pubkey::Pubkey;
+
+/// Represents all types of seeds used for PDAs
+pub enum Seed<'a> {
+    Delegation(&'a Pubkey),
+    DelegationMetadata(&'a Pubkey),
+    Buffer(&'a Pubkey),
+    CommitState(&'a Pubkey),
+    CommitRecord(&'a Pubkey),
+    UndelegateBuffer(&'a Pubkey),
+    ValidatorFeesVault(&'a Pubkey),
+    EphemeralBalance { payer: &'a Pubkey, index: u8 },
+    ProgramConfig(&'a Pubkey),
+    FeesVault,
+}
+
+impl<'a> Seed<'a> {
+    pub fn as_seed_slice(&self) -> Vec<&[u8]> {
+        match self {
+            Seed::Delegation(pubkey) => vec![b"delegation", pubkey.as_ref()],
+            Seed::DelegationMetadata(pubkey) => vec![b"delegation-metadata", pubkey.as_ref()],
+            Seed::Buffer(pubkey) => vec![b"buffer", pubkey.as_ref()],
+            Seed::CommitState(pubkey) => vec![b"state-diff", pubkey.as_ref()],
+            Seed::CommitRecord(pubkey) => vec![b"commit-state-record", pubkey.as_ref()],
+            Seed::UndelegateBuffer(pubkey) => vec![b"undelegate-buffer", pubkey.as_ref()],
+            Seed::ValidatorFeesVault(pubkey) => vec![b"v-fees-vault", pubkey.as_ref()],
+            Seed::ProgramConfig(program_id) => vec![b"p-conf", program_id.as_ref()],
+            Seed::FeesVault => vec![b"fees-vault"],
+            Seed::EphemeralBalance { payer, index } => {
+                let index_ref = std::slice::from_ref(index);
+                vec![b"balance", payer.as_ref(), index_ref]
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🧹 What this PR does

This PR replaces all the legacy `*_seeds_from_*` macro calls with a new strongly typed `Seed<'a>` enum and its associated `as_seed_slice()` method, making PDA derivation more readable, extensible, and safer.

### Summary of changes

- Introduced `Seed<'a>` enum in `seeds.rs`
- Implemented `as_seed_slice()` to convert into `&[&[u8]]` format
- Replaced macro usages in `pda.rs` with equivalent `Seed::X(...).as_seed_slice()` calls
- Removed obsolete macros related to PDA seeds

###  Why?

Moving to a unified, typed API helps:
- Avoid macro spaghetti
- Clarify intent for each seed derivation
- Improve IDE support and refactor tooling