### PR TITLE
fix: actions with account metas

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1945,9 +1945,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783b8b157d4cf81108131afff0bd60d322e2d51deed7dae2d1e3d6bffc8a4b10"
+version = "0.2.1"
+source = "git+https://github.com/magicblock-labs/magicblock-validator.git?rev=9fc26eeefeb26e54f2e41a1121cc7ffd0c94e349#9fc26eeefeb26e54f2e41a1121cc7ffd0c94e349"
 dependencies = [
  "bincode",
  "serde",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "magicblock-magic-program-api"
 version = "0.2.1"
-source = "git+https://github.com/magicblock-labs/magicblock-validator.git?rev=9fc26eeefeb26e54f2e41a1121cc7ffd0c94e349#9fc26eeefeb26e54f2e41a1121cc7ffd0c94e349"
+source = "git+https://github.com/magicblock-labs/magicblock-validator.git?rev=959b63c37eaf07cce31a434c4dcad28ed3d452ef#959b63c37eaf07cce31a434c4dcad28ed3d452ef"
 dependencies = [
  "bincode",
  "serde",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1946,7 +1946,8 @@ dependencies = [
 [[package]]
 name = "magicblock-magic-program-api"
 version = "0.2.1"
-source = "git+https://github.com/magicblock-labs/magicblock-validator.git?rev=959b63c37eaf07cce31a434c4dcad28ed3d452ef#959b63c37eaf07cce31a434c4dcad28ed3d452ef"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349b26eb6d819328dad699a6c9a26234548d366d9a30e7edf0d296180188ee27"
 dependencies = [
  "bincode",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = 
 
 # Magicblock
 magicblock-delegation-program = { version = "1.1.1", features = ["no-entrypoint"] }
-magicblock-magic-program-api = "0.1.7"
+magicblock-magic-program-api = { git ="https://github.com/magicblock-labs/magicblock-validator.git", rev = "9fc26eeefeb26e54f2e41a1121cc7ffd0c94e349" }
 
 ## External crates
 anchor-lang = { version = ">=0.28.0" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = 
 
 # Magicblock
 magicblock-delegation-program = { version = "1.1.1", features = ["no-entrypoint"] }
-magicblock-magic-program-api = { git ="https://github.com/magicblock-labs/magicblock-validator.git", rev = "9fc26eeefeb26e54f2e41a1121cc7ffd0c94e349" }
+magicblock-magic-program-api = { git ="https://github.com/magicblock-labs/magicblock-validator.git", rev = "959b63c37eaf07cce31a434c4dcad28ed3d452ef" }
 
 ## External crates
 anchor-lang = { version = ">=0.28.0" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = 
 
 # Magicblock
 magicblock-delegation-program = { version = "1.1.1", features = ["no-entrypoint"] }
-magicblock-magic-program-api = { git ="https://github.com/magicblock-labs/magicblock-validator.git", rev = "959b63c37eaf07cce31a434c4dcad28ed3d452ef" }
+magicblock-magic-program-api = { version = "0.2.1" }
 
 ## External crates
 anchor-lang = { version = ">=0.28.0" }

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -20,7 +20,7 @@ pub use dlp::{
 };
 pub use magicblock_magic_program_api::args::{
     ActionArgs, BaseActionArgs, CommitAndUndelegateArgs, CommitTypeArgs, MagicBaseIntentArgs,
-    UndelegateTypeArgs,
+    ShortAccountMeta, UndelegateTypeArgs,
 };
 
 pub const fn id() -> Pubkey {


### PR DESCRIPTION
Prior, to form Base layer action users had to include in ER transaction list of accounts they would use in it(Base layer action), now users can form actions using meta information which they could pass as arguments or store for actions in some other account.

Initial apporach had a flaw:
Say user wanted to perform an action: transfer from A to B on base chain. Now say, B is not delegated. This would mean that user would have to explicitly send account B in ER transaction as writable. This would result in him getting an error since we allow only delegated accounts to be writable

Right now user can write:
When validator will send this action to Base chain send account B as writabl