### PR TITLE
refactor: allowing sdk proc-macros to be re-exportable

### DIFF
--- a/rust/commit-attribute/src/lib.rs
+++ b/rust/commit-attribute/src/lib.rs
@@ -30,7 +30,7 @@ pub fn commit(_attr: TokenStream, item: TokenStream) -> TokenStream {
             new_fields.push(
                     Field::parse_named
                         .parse2(quote! {
-                            pub magic_program: Program<'info, ::ephemeral_rollups_sdk::anchor::MagicProgram>
+                            pub magic_program: Program<'info, ephemeral_rollups_sdk::anchor::MagicProgram>
                         })
                         .unwrap(),
                 );
@@ -40,7 +40,7 @@ pub fn commit(_attr: TokenStream, item: TokenStream) -> TokenStream {
             new_fields.push(
                 Field::parse_named
                     .parse2(quote! {
-                        #[account(mut, address = ::ephemeral_rollups_sdk::consts::MAGIC_CONTEXT_ID)]
+                        #[account(mut, address = ephemeral_rollups_sdk::consts::MAGIC_CONTEXT_ID)]
                         /// CHECK:`
                         pub magic_context: AccountInfo<'info>
                     })

--- a/rust/delegate/src/lib.rs
+++ b/rust/delegate/src/lib.rs
@@ -96,9 +96,9 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     &'a self,
                     payer: &'a Signer<'info>,
                     seeds: &[&[u8]],
-                    config: ::ephemeral_rollups_sdk::cpi::DelegateConfig,
+                    config: ephemeral_rollups_sdk::cpi::DelegateConfig,
                 ) -> anchor_lang::solana_program::entrypoint::ProgramResult {
-                    let del_accounts = ::ephemeral_rollups_sdk::cpi::DelegateAccounts {
+                    let del_accounts = ephemeral_rollups_sdk::cpi::DelegateAccounts {
                         payer,
                         pda: &self.#field_name.to_account_info(),
                         owner_program: &self.owner_program,
@@ -108,7 +108,7 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         delegation_program: &self.delegation_program,
                         system_program: &self.system_program,
                     };
-                    ::ephemeral_rollups_sdk::cpi::delegate_account(del_accounts, seeds, config)
+                    ephemeral_rollups_sdk::cpi::delegate_account(del_accounts, seeds, config)
                 }
             });
         }
@@ -143,7 +143,7 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
     if !has_delegation_program {
         new_fields.push(quote! {
             /// CHECK: The delegation program
-            #[account(address = ::ephemeral_rollups_sdk::id())]
+            #[account(address = ephemeral_rollups_sdk::id())]
             pub delegation_program: AccountInfo<'info>,
         });
     }

--- a/rust/ephemeral/src/lib.rs
+++ b/rust/ephemeral/src/lib.rs
@@ -72,7 +72,7 @@ pub fn ephemeral(_args: TokenStream, input: TokenStream) -> TokenStream {
     let modified = modify_component_module(ast);
     TokenStream::from(quote! {
         #[allow(unused_imports)]
-        use ::ephemeral_rollups_sdk::anchor::MagicProgram;
+        use ephemeral_rollups_sdk::anchor::MagicProgram;
 
         #modified
     })


### PR DESCRIPTION
Using `ephemeral_rollups_sdk` instead of `::ephemeral_rollups_sdk`, thus allowing the proc-macros to be re-exportable without the need of also adding `ephemeral_rollups_sdk` as a direct dependency, i.e., it `ephemeral_rollups_sdk` can also be re-exported with its macros.