### PR TITLE
release: 0.3.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-pinocchio"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "pinocchio",
  "pinocchio-log",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "magic-resolver"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.12.3",
  "bincode",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 edition = "2021"
 license = "MIT"
@@ -22,10 +22,10 @@ readme = "README.md"
 keywords = ["solana", "crypto", "delegation", "ephemeral-rollups", "magicblock"]
 
 [workspace.dependencies]
-ephemeral-rollups-sdk = { path = "sdk", version = "=0.3.0" }
-ephemeral-rollups-sdk-attribute-ephemeral = { path = "ephemeral", version = "=0.3.0" }
-ephemeral-rollups-sdk-attribute-delegate = { path = "delegate", version = "=0.3.0" }
-ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = "=0.3.0" }
+ephemeral-rollups-sdk = { path = "sdk", version = "=0.3.1" }
+ephemeral-rollups-sdk-attribute-ephemeral = { path = "ephemeral", version = "=0.3.1" }
+ephemeral-rollups-sdk-attribute-delegate = { path = "delegate", version = "=0.3.1" }
+ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = "=0.3.1" }
 
 # Magicblock
 magicblock-delegation-program = { version = "1.1.1", features = ["no-entrypoint"] }

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-rollups-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "MagicBlock Labs",
   "license": "MIT",
   "publishConfig": {

--- a/ts/src/__tests__/magic-router.test.ts
+++ b/ts/src/__tests__/magic-router.test.ts
@@ -173,7 +173,7 @@ describe("getClosestValidator", () => {
     jest.clearAllMocks();
   });
 
-  it("fetches and returns the closest validator public key", async () => {
+  it("fetches and returns the closest validator info", async () => {
     const mockIdentityData = {
       result: {
         identity: "mock-validator-identity",
@@ -198,7 +198,7 @@ describe("getClosestValidator", () => {
       }),
     });
 
-    expect(result.toBase58()).toBe("mock-validator-identity");
+    expect(result.identity).toBe("mock-validator-identity");
   });
 
   it("handles fetch errors gracefully", async () => {

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -182,14 +182,24 @@ export async function sendAndConfirmMagicTransaction(
     options,
   );
   let status;
-  if ((transaction.recentBlockhash != null) && (transaction.lastValidBlockHeight != null)) {
+  if (
+    transaction.recentBlockhash !== null &&
+    transaction.recentBlockhash !== undefined &&
+    transaction.lastValidBlockHeight !== null &&
+    transaction.lastValidBlockHeight !== undefined
+  ) {
       status = (await connection.confirmTransaction({
       abortSignal: options?.abortSignal,
       signature: signature,
       blockhash: transaction.recentBlockhash,
       lastValidBlockHeight: transaction.lastValidBlockHeight
       }, options?.commitment)).value;
-  } else if ((transaction.minNonceContextSlot != null) && (transaction.nonceInfo != null)) {
+  } else if (
+    transaction.minNonceContextSlot !== null &&
+    transaction.minNonceContextSlot !== undefined &&
+    transaction.nonceInfo !== null &&
+    transaction.nonceInfo !== undefined
+  ) {
       const {
       nonceInstruction
       } = transaction.nonceInfo;

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -49,9 +49,10 @@ export async function getClosestValidator(routerConnection: Connection) : Promis
 
   const identityData = (await response.json())?.result;
 
-  if (!identityData || !identityData.identity) {
+  if (identityData == null || identityData.identity == null) {
     throw new Error("Invalid response");
   }
+
 
   return identityData;
 }

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -49,7 +49,7 @@ export async function getClosestValidator(routerConnection: Connection) : Promis
 
   const identityData = (await response.json())?.result;
 
-  if (identityData == undefined || identityData.identity == undefined) {
+  if ((identityData == null) || (identityData.identity == null)) {
     throw new Error("Invalid response");
   }
 
@@ -208,13 +208,13 @@ export async function sendAndConfirmMagicTransaction(
       signature
       }, options?.commitment)).value;
   } else {
-      if (options?.abortSignal !== undefined) {
+      if (options?.abortSignal !== null) {
       console.warn('sendAndConfirmTransaction(): A transaction with a deprecated confirmation strategy was ' + 'supplied along with an `abortSignal`. Only transactions having `lastValidBlockHeight` ' + 'or a combination of `nonceInfo` and `minNonceContextSlot` are abortable.');
       }
       status = (await connection.confirmTransaction(signature, options?.commitment)).value;
   }
   if (status.err) {
-      if (signature !== undefined) {
+      if (signature !== null) {
       throw new SendTransactionError({
           action: 'send',
           signature: signature,

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -205,7 +205,7 @@ export async function sendAndConfirmMagicTransaction(
       if (options?.abortSignal != null) {
       console.warn('sendAndConfirmTransaction(): A transaction with a deprecated confirmation strategy was ' + 'supplied along with an `abortSignal`. Only transactions having `lastValidBlockHeight` ' + 'or a combination of `nonceInfo` and `minNonceContextSlot` are abortable.');
       }
-      status = (await connection.confirmTransaction(signature, options && options.commitment)).value;
+      status = (await connection.confirmTransaction(signature, options?.commitment)).value;
   }
   if (status.err) {
       if (signature != null) {

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -188,7 +188,7 @@ export async function sendAndConfirmMagicTransaction(
       signature: signature,
       blockhash: transaction.recentBlockhash,
       lastValidBlockHeight: transaction.lastValidBlockHeight
-      }, options && options.commitment)).value;
+      }, options?.commitment)).value;
   } else if (transaction.minNonceContextSlot != null && transaction.nonceInfo != null) {
       const {
       nonceInstruction
@@ -200,7 +200,7 @@ export async function sendAndConfirmMagicTransaction(
       nonceAccountPubkey,
       nonceValue: transaction.nonceInfo.nonce,
       signature
-      }, options && options.commitment)).value;
+      }, options?.commitment)).value;
   } else {
       if (options?.abortSignal != null) {
       console.warn('sendAndConfirmTransaction(): A transaction with a deprecated confirmation strategy was ' + 'supplied along with an `abortSignal`. Only transactions having `lastValidBlockHeight` ' + 'or a combination of `nonceInfo` and `minNonceContextSlot` are abortable.');

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -49,7 +49,7 @@ export async function getClosestValidator(routerConnection: Connection) : Promis
 
   const identityData = (await response.json())?.result;
 
-  if (identityData == null || identityData.identity == null) {
+  if (identityData == undefined || identityData.identity == undefined) {
     throw new Error("Invalid response");
   }
 
@@ -184,7 +184,7 @@ export async function sendAndConfirmMagicTransaction(
   let status;
   const { recentBlockhash, lastValidBlockHeight, minNonceContextSlot, nonceInfo } = transaction;
   if (
-    recentBlockhash != undefined && lastValidBlockHeight != undefined
+    recentBlockhash !== undefined && lastValidBlockHeight !== undefined
   ) {
       status = (await connection.confirmTransaction({
       abortSignal: options?.abortSignal,
@@ -193,8 +193,8 @@ export async function sendAndConfirmMagicTransaction(
       lastValidBlockHeight: lastValidBlockHeight
       }, options?.commitment)).value;
   } else if (
-    minNonceContextSlot != undefined &&
-    nonceInfo != undefined
+    minNonceContextSlot !== undefined &&
+    nonceInfo !== undefined
   ) {
       const {
         nonceInstruction
@@ -208,13 +208,13 @@ export async function sendAndConfirmMagicTransaction(
       signature
       }, options?.commitment)).value;
   } else {
-      if (options?.abortSignal != undefined) {
+      if (options?.abortSignal !== undefined) {
       console.warn('sendAndConfirmTransaction(): A transaction with a deprecated confirmation strategy was ' + 'supplied along with an `abortSignal`. Only transactions having `lastValidBlockHeight` ' + 'or a combination of `nonceInfo` and `minNonceContextSlot` are abortable.');
       }
       status = (await connection.confirmTransaction(signature, options?.commitment)).value;
   }
   if (status.err) {
-      if (signature != undefined) {
+      if (signature !== undefined) {
       throw new SendTransactionError({
           action: 'send',
           signature: signature,

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -7,16 +7,8 @@ import {
   BlockhashWithExpiryBlockHeight,
   SendOptions,
   PublicKey,
-  TransactionConfirmationStrategy,
-  RpcResponseAndContext,
-  SignatureResult,
-  Commitment,
   SendTransactionError,
-  SignatureStatusConfig,
-  SignatureStatus,
 } from "@solana/web3.js";
-import assert from "assert";
-import bs58 from "bs58";
 
 /**
  * Get all writable accounts from a transaction.
@@ -41,9 +33,9 @@ export function getWritableAccounts(transaction: Transaction) {
 }
 
 /**
- * Get the closest validator's public key from the router connection.
+ * Get the closest validator info from the router connection.
  */
-export async function getClosestValidator(routerConnection: Connection) {
+export async function getClosestValidator(routerConnection: Connection) : Promise<{ identity: string; fqdn?: string }> {
   const response = await fetch(routerConnection.rpcEndpoint, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -55,19 +47,13 @@ export async function getClosestValidator(routerConnection: Connection) {
     }),
   });
 
-  const identityData = await response.json();
-  const identity = identityData?.result?.identity;
-  if (typeof identity !== "string") {
-    throw new Error("Invalid identity response");
-  }
-  // Return a lightweight object exposing toBase58/toString to avoid requiring
-  // a real PublicKey instance in environments/tests that mock web3.js
-  const validatorKey = {
-    toBase58: () => identity,
-    toString: () => identity,
-  } as unknown as PublicKey;
+  const identityData = (await response.json())?.result;
 
-  return validatorKey;
+  if (!identityData || !identityData.identity) {
+    throw new Error("Invalid response");
+  }
+
+  return identityData;
 }
 
 /**
@@ -177,48 +163,7 @@ export async function sendMagicTransaction(
 }
 
 /**
- * Confirm a transaction, returning the status of the transaction.
- * This function is modified to handle the magic transaction confirmation strategy.
- * ONLY supports polling for now.
- */
-export async function confirmMagicTransaction(
-  connection: Connection,
-  strategy: TransactionConfirmationStrategy | string,
-  commitment?: Commitment,
-): Promise<RpcResponseAndContext<SignatureResult>> {
-  let rawSignature;
-  if (typeof strategy === "string") {
-    rawSignature = strategy;
-  } else {
-    const config = strategy;
-    if (config.abortSignal != null && config.abortSignal.aborted) {
-      return Promise.reject(config.abortSignal.reason ?? new Error("Aborted"));
-    }
-    rawSignature = config.signature;
-  }
-  let decodedSignature;
-  try {
-    decodedSignature = bs58.decode(rawSignature);
-  } catch (err) {
-    throw new Error("signature must be base58 encoded: " + rawSignature);
-  }
-  assert(decodedSignature.length === 64, "signature has invalid length");
-  const status = await pollSignatureStatus(
-    getSignatureStatus,
-    connection,
-    rawSignature,
-    {
-      intervalMs: 100,
-      timeoutMs: 10_000,
-      commitment,
-    },
-  );
-  return status;
-}
-
-/**
  * Send and confirm a transaction, returning the signature of the transaction.
- * ONLY supports polling for now.
  */
 export async function sendAndConfirmMagicTransaction(
   connection: Connection,
@@ -236,191 +181,40 @@ export async function sendAndConfirmMagicTransaction(
     options,
   );
   let status;
-  if (
-    transaction.recentBlockhash != null &&
-    transaction.lastValidBlockHeight != null
-  ) {
-    status = (
-      await confirmMagicTransaction(
-        connection,
-        {
-          abortSignal: options?.abortSignal,
-          signature,
-          blockhash: transaction.recentBlockhash,
-          lastValidBlockHeight: transaction.lastValidBlockHeight,
-        },
-        options?.commitment,
-      )
-    ).value;
-  } else if (
-    transaction.minNonceContextSlot != null &&
-    transaction.nonceInfo != null
-  ) {
-    const { nonceInstruction } = transaction.nonceInfo;
-    const nonceAccountPubkey = nonceInstruction.keys[0].pubkey;
-    status = (
-      await confirmMagicTransaction(
-        connection,
-        {
-          abortSignal: options?.abortSignal,
-          minContextSlot: transaction.minNonceContextSlot,
-          nonceAccountPubkey,
-          nonceValue: transaction.nonceInfo.nonce,
-          signature,
-        },
-        options?.commitment,
-      )
-    ).value;
+  if (transaction.recentBlockhash != null && transaction.lastValidBlockHeight != null) {
+      status = (await connection.confirmTransaction({
+      abortSignal: options?.abortSignal,
+      signature: signature,
+      blockhash: transaction.recentBlockhash,
+      lastValidBlockHeight: transaction.lastValidBlockHeight
+      }, options && options.commitment)).value;
+  } else if (transaction.minNonceContextSlot != null && transaction.nonceInfo != null) {
+      const {
+      nonceInstruction
+      } = transaction.nonceInfo;
+      const nonceAccountPubkey = nonceInstruction.keys[0].pubkey;
+      status = (await connection.confirmTransaction({
+      abortSignal: options?.abortSignal,
+      minContextSlot: transaction.minNonceContextSlot,
+      nonceAccountPubkey,
+      nonceValue: transaction.nonceInfo.nonce,
+      signature
+      }, options && options.commitment)).value;
   } else {
-    if (options?.abortSignal != null) {
-      console.warn(
-        "sendAndConfirmTransaction(): A transaction with a deprecated confirmation strategy was " +
-          "supplied along with an `abortSignal`. Only transactions having `lastValidBlockHeight` " +
-          "or a combination of `nonceInfo` and `minNonceContextSlot` are abortable.",
-      );
-    }
-    status = (
-      await confirmMagicTransaction(connection, signature, options?.commitment)
-    ).value;
+      if (options?.abortSignal != null) {
+      console.warn('sendAndConfirmTransaction(): A transaction with a deprecated confirmation strategy was ' + 'supplied along with an `abortSignal`. Only transactions having `lastValidBlockHeight` ' + 'or a combination of `nonceInfo` and `minNonceContextSlot` are abortable.');
+      }
+      status = (await connection.confirmTransaction(signature, options && options.commitment)).value;
   }
-  if (status.err != null) {
-    if (signature != null) {
+  if (status.err) {
+      if (signature != null) {
       throw new SendTransactionError({
-        action: "send",
-        signature,
-        transactionMessage: `Status: (${JSON.stringify(status)})`,
+          action: 'send',
+          signature: signature,
+          transactionMessage: `Status: (${JSON.stringify(status)})`
       });
-    }
-    throw new Error(
-      `Transaction ${signature} failed (${JSON.stringify(status)})`,
-    );
+      }
+      throw new Error(`Transaction ${signature} failed (${JSON.stringify(status)})`);
   }
   return signature;
-}
-
-/**
- * Fetch the current status of a signature
- */
-async function getSignatureStatus(
-  connection: Connection,
-  signature: TransactionSignature,
-  config?: SignatureStatusConfig,
-): Promise<RpcResponseAndContext<SignatureStatus | null>> {
-  const { context, value: values } = await getSignatureStatuses(
-    connection,
-    [signature],
-    config,
-  );
-
-  if (values.length === 0) {
-    const value = null;
-    return {
-      context,
-      value,
-    };
-  } else {
-    assert(values.length === 1);
-    const value = values[0];
-    return {
-      context,
-      value,
-    };
-  }
-}
-
-/**
- * Fetch the current statuses of a batch of signatures
- */
-async function getSignatureStatuses(
-  connection: Connection,
-  signatures: TransactionSignature[],
-  config?: SignatureStatusConfig,
-): Promise<RpcResponseAndContext<Array<SignatureStatus | null>>> {
-  const params = config ? [signatures, config] : [signatures];
-  const unsafeRes = await fetch(connection.rpcEndpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "getSignatureStatuses",
-      params,
-    }),
-  });
-  const res = await unsafeRes.json();
-  // const res = superstruct.create(unsafeRes, GetSignatureStatusesRpcResult);
-  // if ('error' in res) {
-  // throw new SolanaJSONRPCError(res.error, 'failed to get signature status');
-  // }
-  return res.result;
-}
-
-/**
- * Poll the current status of a signature
- */
-export async function pollSignatureStatus(
-  getSignatureStatus: (
-    connection: Connection,
-    signature: TransactionSignature,
-    config?: SignatureStatusConfig,
-  ) => Promise<RpcResponseAndContext<SignatureStatus | null>>,
-  connection: Connection,
-  signature: string,
-  {
-    intervalMs = 50,
-    timeoutMs = 12_000,
-    commitment = "confirmed",
-    abortSignal,
-  }: {
-    intervalMs?: number;
-    timeoutMs?: number;
-    commitment?: Commitment;
-    abortSignal?: AbortSignal;
-  } = {},
-): Promise<RpcResponseAndContext<SignatureResult>> {
-  const maxTries = Math.ceil(timeoutMs / intervalMs);
-  let tries = 0;
-
-  return new Promise((resolve, reject) => {
-    const intervalId = setInterval(() => {
-      if (abortSignal != null && abortSignal.aborted) {
-        clearInterval(intervalId);
-        reject(abortSignal.reason ?? new Error("Polling aborted"));
-        return;
-      }
-
-      tries++;
-
-      void (async () => {
-        try {
-          const result = await getSignatureStatus(connection, signature);
-          if (result.value !== null) {
-            if (
-              result.value.confirmationStatus === commitment ||
-              result.value.confirmationStatus === "finalized"
-            ) {
-              clearInterval(intervalId);
-              resolve({
-                context: result.context,
-                value: result.value as SignatureResult,
-              });
-            }
-          } else if (tries >= maxTries) {
-            clearInterval(intervalId);
-            const timeoutValue: SignatureResult = {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              err: new Error("Timeout") as unknown as any,
-            };
-            resolve({
-              context: result.context,
-              value: timeoutValue,
-            });
-          }
-        } catch (err) {
-          clearInterval(intervalId);
-          reject(err);
-        }
-      })();
-    }, intervalMs);
-  });
 }

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -182,33 +182,29 @@ export async function sendAndConfirmMagicTransaction(
     options,
   );
   let status;
+  const { recentBlockhash, lastValidBlockHeight, minNonceContextSlot, nonceInfo } = transaction;
   if (
-    transaction.recentBlockhash !== null &&
-    transaction.recentBlockhash !== undefined &&
-    transaction.lastValidBlockHeight !== null &&
-    transaction.lastValidBlockHeight !== undefined
+    recentBlockhash != null && lastValidBlockHeight != null
   ) {
       status = (await connection.confirmTransaction({
       abortSignal: options?.abortSignal,
       signature: signature,
-      blockhash: transaction.recentBlockhash,
-      lastValidBlockHeight: transaction.lastValidBlockHeight
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: lastValidBlockHeight
       }, options?.commitment)).value;
   } else if (
-    transaction.minNonceContextSlot !== null &&
-    transaction.minNonceContextSlot !== undefined &&
-    transaction.nonceInfo !== null &&
-    transaction.nonceInfo !== undefined
+    minNonceContextSlot != null &&
+    nonceInfo != null
   ) {
       const {
-      nonceInstruction
-      } = transaction.nonceInfo;
+        nonceInstruction
+      } = nonceInfo;
       const nonceAccountPubkey = nonceInstruction.keys[0].pubkey;
       status = (await connection.confirmTransaction({
       abortSignal: options?.abortSignal,
-      minContextSlot: transaction.minNonceContextSlot,
+      minContextSlot: minNonceContextSlot,
       nonceAccountPubkey,
-      nonceValue: transaction.nonceInfo.nonce,
+      nonceValue: nonceInfo.nonce,
       signature
       }, options?.commitment)).value;
   } else {

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -182,14 +182,14 @@ export async function sendAndConfirmMagicTransaction(
     options,
   );
   let status;
-  if (transaction.recentBlockhash != null && transaction.lastValidBlockHeight != null) {
+  if ((transaction.recentBlockhash != null) && (transaction.lastValidBlockHeight != null)) {
       status = (await connection.confirmTransaction({
       abortSignal: options?.abortSignal,
       signature: signature,
       blockhash: transaction.recentBlockhash,
       lastValidBlockHeight: transaction.lastValidBlockHeight
       }, options?.commitment)).value;
-  } else if (transaction.minNonceContextSlot != null && transaction.nonceInfo != null) {
+  } else if ((transaction.minNonceContextSlot != null) && (transaction.nonceInfo != null)) {
       const {
       nonceInstruction
       } = transaction.nonceInfo;

--- a/ts/src/magic-router.ts
+++ b/ts/src/magic-router.ts
@@ -184,7 +184,7 @@ export async function sendAndConfirmMagicTransaction(
   let status;
   const { recentBlockhash, lastValidBlockHeight, minNonceContextSlot, nonceInfo } = transaction;
   if (
-    recentBlockhash != null && lastValidBlockHeight != null
+    recentBlockhash != undefined && lastValidBlockHeight != undefined
   ) {
       status = (await connection.confirmTransaction({
       abortSignal: options?.abortSignal,
@@ -193,8 +193,8 @@ export async function sendAndConfirmMagicTransaction(
       lastValidBlockHeight: lastValidBlockHeight
       }, options?.commitment)).value;
   } else if (
-    minNonceContextSlot != null &&
-    nonceInfo != null
+    minNonceContextSlot != undefined &&
+    nonceInfo != undefined
   ) {
       const {
         nonceInstruction
@@ -208,13 +208,13 @@ export async function sendAndConfirmMagicTransaction(
       signature
       }, options?.commitment)).value;
   } else {
-      if (options?.abortSignal != null) {
+      if (options?.abortSignal != undefined) {
       console.warn('sendAndConfirmTransaction(): A transaction with a deprecated confirmation strategy was ' + 'supplied along with an `abortSignal`. Only transactions having `lastValidBlockHeight` ' + 'or a combination of `nonceInfo` and `minNonceContextSlot` are abortable.');
       }
       status = (await connection.confirmTransaction(signature, options?.commitment)).value;
   }
   if (status.err) {
-      if (signature != null) {
+      if (signature != undefined) {
       throw new SendTransactionError({
           action: 'send',
           signature: signature,


### PR DESCRIPTION
- updated magic-router sdk to confirm tx from polling to websocket subscription `signatureSubscribe`
- updated `getClosestValidator` response to return both identity and endpoint url