### PR TITLE
feat: remove force update

### DIFF
--- a/ts/kit/src/access-control/permission.ts
+++ b/ts/kit/src/access-control/permission.ts
@@ -12,7 +12,7 @@ export interface PermissionStatusResponse {
  */
 export async function getPermissionStatus(
   rpcUrl: string,
-  publicKey: Address,
+  publicKey: Address
 ): Promise<PermissionStatusResponse> {
   // Build the route from the provided RPC URL
   // Handle the provided token
@@ -28,7 +28,7 @@ export async function getPermissionStatus(
     const permissionStatusResponse = await fetch(url);
     if (!permissionStatusResponse.ok) {
       throw new Error(
-        `Permission status request failed: ${permissionStatusResponse.statusText}`,
+        `Permission status request failed: ${permissionStatusResponse.statusText}`
       );
     }
     const response: PermissionStatusResponse =
@@ -36,44 +36,8 @@ export async function getPermissionStatus(
     return response;
   } catch (error) {
     throw new Error(
-      `Failed to get permission status: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to get permission status: ${error instanceof Error ? error.message : String(error)}`
     );
-  }
-}
-
-/**
- * Force update permissions for a given public key
- * @param rpcUrl - The URL of the RPC server
- * @param publicKey - The public key of the user
- * @returns True if the force update was successful, false otherwise
- */
-async function forcePermissionUpdate(
-  rpcUrl: string,
-  publicKey: Address,
-): Promise<boolean> {
-  // Build the route from the provided RPC URL
-  // Handle the provided token
-  const [baseUrl, token] = rpcUrl.replace("/?", "?").split("?");
-  let url;
-  if (token) {
-    url = `${baseUrl}/permission/force-update?${token}&pubkey=${publicKey.toString()}`;
-  } else {
-    url = `${baseUrl}/permission/force-update?pubkey=${publicKey.toString()}`;
-  }
-
-  try {
-    const forceUpdateResponse = await fetch(url);
-    if (!forceUpdateResponse.ok) {
-      throw new Error(
-        `Force permission update request failed: ${forceUpdateResponse.statusText}`,
-      );
-    }
-    return true;
-  } catch (error) {
-    console.error(
-      `Failed to force permission update: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return false;
   }
 }
 
@@ -87,7 +51,7 @@ async function forcePermissionUpdate(
 export async function waitUntilPermissionActive(
   rpcUrl: string,
   publicKey: Address,
-  timeout?: number,
+  timeout?: number
 ): Promise<boolean> {
   const timeoutMs = timeout ?? 5000;
 
@@ -106,30 +70,6 @@ export async function waitUntilPermissionActive(
     await new Promise((resolve) => {
       setTimeout(resolve, 400);
     });
-  }
-
-  // If timeout reached, try force permission update as fallback
-  const forceUpdateSuccess = await forcePermissionUpdate(rpcUrl, publicKey);
-  if (forceUpdateSuccess) {
-    // Retry permission status for another 5 seconds after force update
-    startTime = Date.now();
-    while (Date.now() - startTime < timeoutMs) {
-      try {
-        const { authorizedUsers } = await getPermissionStatus(
-          rpcUrl,
-          publicKey,
-        );
-        if (authorizedUsers && authorizedUsers.length > 0) {
-          return true;
-        }
-      } catch (error) {
-        console.error(error);
-      }
-
-      await new Promise((resolve) => {
-        setTimeout(resolve, 400);
-      });
-    }
   }
 
   return false;

--- a/ts/web3js/src/access-control/permission.ts
+++ b/ts/web3js/src/access-control/permission.ts
@@ -12,7 +12,7 @@ export interface PermissionStatusResponse {
  */
 export async function getPermissionStatus(
   rpcUrl: string,
-  publicKey: PublicKey,
+  publicKey: PublicKey
 ): Promise<PermissionStatusResponse> {
   // Build the route from the provided RPC URL
   // Handle the provided token
@@ -28,7 +28,7 @@ export async function getPermissionStatus(
     const permissionStatusResponse = await fetch(url);
     if (!permissionStatusResponse.ok) {
       throw new Error(
-        `Permission status request failed: ${permissionStatusResponse.statusText}`,
+        `Permission status request failed: ${permissionStatusResponse.statusText}`
       );
     }
     const response: PermissionStatusResponse =
@@ -36,44 +36,8 @@ export async function getPermissionStatus(
     return response;
   } catch (error) {
     throw new Error(
-      `Failed to get permission status: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to get permission status: ${error instanceof Error ? error.message : String(error)}`
     );
-  }
-}
-
-/**
- * Force update permissions for a given public key
- * @param rpcUrl - The URL of the RPC server
- * @param publicKey - The public key of the user
- * @returns True if the force update was successful, false otherwise
- */
-async function forcePermissionUpdate(
-  rpcUrl: string,
-  publicKey: PublicKey,
-): Promise<boolean> {
-  // Build the route from the provided RPC URL
-  // Handle the provided token
-  const [baseUrl, token] = rpcUrl.replace("/?", "?").split("?");
-  let url;
-  if (token) {
-    url = `${baseUrl}/permission/force-update?${token}&pubkey=${publicKey.toString()}`;
-  } else {
-    url = `${baseUrl}/permission/force-update?pubkey=${publicKey.toString()}`;
-  }
-
-  try {
-    const forceUpdateResponse = await fetch(url);
-    if (!forceUpdateResponse.ok) {
-      throw new Error(
-        `Force permission update request failed: ${forceUpdateResponse.statusText}`,
-      );
-    }
-    return true;
-  } catch (error) {
-    console.error(
-      `Failed to force permission update: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return false;
   }
 }
 
@@ -87,7 +51,7 @@ async function forcePermissionUpdate(
 export async function waitUntilPermissionActive(
   rpcUrl: string,
   publicKey: PublicKey,
-  timeout?: number,
+  timeout?: number
 ): Promise<boolean> {
   const timeoutMs = timeout ?? 5000;
 
@@ -106,30 +70,6 @@ export async function waitUntilPermissionActive(
     await new Promise((resolve) => {
       setTimeout(resolve, 400);
     });
-  }
-
-  // If timeout reached, try force permission update as fallback
-  const forceUpdateSuccess = await forcePermissionUpdate(rpcUrl, publicKey);
-  if (forceUpdateSuccess) {
-    // Retry permission status for another 5 seconds after force update
-    startTime = Date.now();
-    while (Date.now() - startTime < timeoutMs) {
-      try {
-        const { authorizedUsers } = await getPermissionStatus(
-          rpcUrl,
-          publicKey,
-        );
-        if (authorizedUsers && authorizedUsers.length > 0) {
-          return true;
-        }
-      } catch (error) {
-        console.error(error);
-      }
-
-      await new Promise((resolve) => {
-        setTimeout(resolve, 400);
-      });
-    }
   }
 
   return false;


### PR DESCRIPTION
`/permission/force-update` route has been removed after the refactoring of permission on the TEE. Now, instead of having the TEE subscribing to permissions on mainnet, it directly queries the colocated validator to get permissions using cloned data. This is a slightly slower approach (more network queries, especially for never-seen-before accounts) but much more robust with no chance of missing the permission. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified permission verification logic by eliminating unused retry mechanisms while maintaining existing API compatibility and error handling behavior. Permission checks now complete through a single polling cycle without fallback paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->