### PR TITLE
Fix incorrect script name

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -7,7 +7,7 @@
    Increment the version number in the `Cargo.toml` file according to the release type (major, minor, or patch).
 
 3. **Align Versions**  
-   Run the `.version-align.sh` script. This will:
+   Run the `version_align.sh` script. This will:
     - Update the version of all internal crates and npm packages.
     - Generate the updated crates.
 


### PR DESCRIPTION
Updated `RELEASE_PROCESS.md` to reference the correct script name (`version_align.sh`) instead of the non-existent `.version-align.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation with refined script references and improved formatting for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->