### PR TITLE
Fix README import

### DIFF
--- a/ts/kit/README.md
+++ b/ts/kit/README.md
@@ -15,6 +15,6 @@ yarn add @magicblock-labs/ephemeral-rollups-kit
 
 ## Usage (basic)
 
-import { Connection } from "@magicblock-labs/ephemeral-rollups-sdk";
+import { Connection } from "@magicblock-labs/ephemeral-rollups-kit";
 
 // See full examples and docs in the Quickstart link above.


### PR DESCRIPTION
## Changes:
Incorrect import replaced:
```ts
import { MagicRouter } from "@magicblock-labs/ephemeral-rollups-kit";
```
with:
```ts
import { Connection } from "@magicblock-labs/ephemeral-rollups-sdk";
```
## Reason / Analysis:
In `ts/kit/src/index.ts`, the following are exported:
```ts
export * from "./constants.js";
export * from "./pda.js";
export * from "./utils.js";
export * from "./resolver.js";
export * from "./connection.js";
export * from "./confirmation.js";
export * from "./instructions/index.js";
export * from "./access-control/index.js";
```

MagicRouter is not included in this package (it only exists in `web3js` as `ConnectionMagicRouter`).

The main API is `Connection`, exported from `connection.js`.

I did not write the connection logic, as the README states the following:
```ts
// See full examples and docs in the Quickstart link above.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the usage example in the README to reflect current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->