### PR TITLE
fix(ws): use programSubscribe instead of getProgramAccounts

### DIFF
--- a/rust/resolver/src/websocket/connection/routes.rs
+++ b/rust/resolver/src/websocket/connection/routes.rs
@@ -152,8 +152,14 @@ impl WsRoutesConnection {
             {{
                 "jsonrpc": "2.0",
                 "id": 1,
-                "method": "getProgramAccounts",
-                "params": ["{}"]
+                "method": "programSubscribe",
+                "params": [
+                    "{}",
+                    {{
+                        "encoding": "base64",
+                        "commitment": "confirmed"
+                    }}
+                ]
             }}
             "#,
             mdp::id()


### PR DESCRIPTION
## Summary

Replace `getProgramAccounts` with `programSubscribe` in WebSocket subscription.

## Problem

`getProgramAccounts` is an HTTP RPC method and does not create a WebSocket subscription, while the code expects `Subscribed` and `programNotification` messages.

As a result, no real-time updates are received and the routing table can become stale.

## Solution

Switch to `programSubscribe` with proper params (`encoding`, `commitment`) to enable real-time updates.

## Result

WebSocket connection now receives live updates and existing message handling works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced websocket subscription mechanism for program account monitoring with refined request parameters. Updated to standardize data encoding format and confirm ledger commitment levels, ensuring more consistent data retrieval and improved system reliability during real-time synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->