### PR TITLE
refactor: depend on dlp_api only, not on dlp anymore

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -960,7 +960,6 @@ dependencies = [
  "fiat-crypto",
  "rand_core 0.6.4",
  "rustc_version",
- "serde",
  "subtle",
  "zeroize",
 ]
@@ -2210,14 +2209,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "magicblock-delegation-program"
-version = "1.1.3"
-source = "git+https://github.com/magicblock-labs/delegation-program.git?rev=abf340536e88740c290b2b3af4e3d1ff38240f63#abf340536e88740c290b2b3af4e3d1ff38240f63"
+name = "magicblock-delegation-program-api"
+version = "0.1.0"
+source = "git+https://github.com/magicblock-labs/delegation-program.git?rev=2bf5382808942e8cc3cef6fe927a9c6c63fc7a79#2bf5382808942e8cc3cef6fe927a9c6c63fc7a79"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.6.0",
  "bytemuck",
  "const-crypto",
+ "libsodium-rs",
  "num_enum",
  "pinocchio 0.10.1",
  "pinocchio-log",
@@ -2226,27 +2226,12 @@ dependencies = [
  "rkyv 0.7.46",
  "serde",
  "solana-address",
- "solana-curve25519",
  "solana-instruction 3.1.0",
  "solana-program",
+ "solana-sdk",
  "solana-sha256-hasher 3.1.0",
  "static_assertions",
  "strum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "magicblock-delegation-program-api"
-version = "0.1.0"
-source = "git+https://github.com/magicblock-labs/delegation-program.git?rev=abf340536e88740c290b2b3af4e3d1ff38240f63#abf340536e88740c290b2b3af4e3d1ff38240f63"
-dependencies = [
- "bincode 1.3.3",
- "borsh 1.6.0",
- "libsodium-rs",
- "magicblock-delegation-program",
- "serde",
- "solana-program",
- "solana-sdk",
  "thiserror 1.0.69",
 ]
 
@@ -3712,20 +3697,6 @@ dependencies = [
  "solana-program-error 2.2.2",
  "solana-pubkey 2.4.0",
  "solana-stable-layout",
-]
-
-[[package]]
-name = "solana-curve25519"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ee66a3e25ed8d20ed6fcd1ac71735415ff1edaf33ff1ec2118826eba927bcc"
-dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek 4.1.3",
- "solana-define-syscall 5.0.0",
- "subtle",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 
 
 # Magicblock
-magicblock-delegation-program-api = { git = "https://github.com/magicblock-labs/delegation-program.git", rev = "abf340536e88740c290b2b3af4e3d1ff38240f63", default-features = false }
+magicblock-delegation-program-api = { git = "https://github.com/magicblock-labs/delegation-program.git", rev = "2bf5382808942e8cc3cef6fe927a9c6c63fc7a79", default-features = false }
 
 magicblock-magic-program-api = { version = "0.8.1", default-features = false }
 

--- a/rust/pinocchio/src/instruction/delegate_with_actions.rs
+++ b/rust/pinocchio/src/instruction/delegate_with_actions.rs
@@ -11,7 +11,7 @@ use crate::pda::find_program_address;
 use crate::types::DelegateAccountArgs;
 use crate::utils::{cpi_delegate_with_actions, make_seed_buf};
 use crate::{consts::BUFFER, types::DelegateConfig, utils::close_pda_acc};
-pub use dlp_api::dlp::{
+pub use dlp_api::{
     args::{
         EncryptedBuffer, MaybeEncryptedAccountMeta, MaybeEncryptedInstruction,
         MaybeEncryptedIxData, MaybeEncryptedPubkey, PostDelegationActions,

--- a/rust/pinocchio/src/utils.rs
+++ b/rust/pinocchio/src/utils.rs
@@ -173,11 +173,11 @@ fn cpi_delegate_with_discriminator(
 #[cfg(feature = "delegation-actions")]
 pub fn serialize_delegate_with_actions_data(
     delegate_args: DelegateAccountArgs,
-    actions: dlp_api::dlp::args::PostDelegationActions,
+    actions: dlp_api::args::PostDelegationActions,
 ) -> Result<alloc::vec::Vec<u8>, ProgramError> {
     use alloc::vec::Vec;
-    use dlp_api::dlp::args::{DelegateArgs, DelegateWithActionsArgs};
-    use dlp_api::dlp::discriminator::DlpDiscriminator;
+    use dlp_api::args::{DelegateArgs, DelegateWithActionsArgs};
+    use dlp_api::discriminator::DlpDiscriminator;
     use solana_program::pubkey::Pubkey;
 
     let seeds_vec: Vec<Vec<u8>> = delegate_args.seeds.iter().map(|s| s.to_vec()).collect();
@@ -207,7 +207,7 @@ pub fn cpi_delegate_with_actions(
     delegation_metadata: &AccountView,
     system_program: &AccountView,
     delegate_args: DelegateAccountArgs,
-    actions: dlp_api::dlp::args::PostDelegationActions,
+    actions: dlp_api::args::PostDelegationActions,
     action_signer_accounts: &[&AccountView],
     signer_seeds: Signer<'_, '_>,
 ) -> Result<(), ProgramError> {

--- a/rust/sdk/src/consts.rs
+++ b/rust/sdk/src/consts.rs
@@ -1,6 +1,6 @@
 use crate::solana_compat::solana::Pubkey;
 
-pub use dlp_api::dlp::consts::*;
+pub use dlp_api::consts::*;
 use magicblock_magic_program_api::{EPHEMERAL_VAULT_PUBKEY, MAGIC_CONTEXT_PUBKEY};
 
 /// The magic program ID.

--- a/rust/sdk/src/cpi.rs
+++ b/rust/sdk/src/cpi.rs
@@ -1,9 +1,9 @@
 use crate::types::DelegateAccountArgs;
 use crate::utils::{close_pda_with_system_transfer, create_pda, seeds_with_bump};
 use borsh::{to_vec, BorshSerialize};
-use dlp_api::dlp::args::{DelegateArgs, DelegateWithActionsArgs, PostDelegationActions};
-use dlp_api::dlp::delegate_buffer_seeds_from_delegated_account;
-use dlp_api::dlp::discriminator::DlpDiscriminator;
+use dlp_api::args::{DelegateArgs, DelegateWithActionsArgs, PostDelegationActions};
+use dlp_api::delegate_buffer_seeds_from_delegated_account;
+use dlp_api::discriminator::DlpDiscriminator;
 
 use crate::solana_compat::solana::{
     invoke_signed, sol_memset, system_instruction, AccountInfo, AccountMeta, Instruction,
@@ -11,7 +11,7 @@ use crate::solana_compat::solana::{
 };
 
 pub const DELEGATION_PROGRAM_ID: Pubkey =
-    Pubkey::new_from_array(dlp_api::dlp::consts::DELEGATION_PROGRAM_ID.to_bytes());
+    Pubkey::new_from_array(dlp_api::consts::DELEGATION_PROGRAM_ID.to_bytes());
 
 pub struct DelegateAccounts<'a, 'info> {
     pub payer: &'a AccountInfo<'info>,

--- a/rust/sdk/src/delegate_args.rs
+++ b/rust/sdk/src/delegate_args.rs
@@ -1,5 +1,5 @@
 use crate::solana_compat::solana::{system_program, AccountMeta, Pubkey};
-use dlp_api::dlp::pda::{
+use dlp_api::pda::{
     delegate_buffer_pda_from_delegated_account_and_owner_program,
     delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
 };

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -21,9 +21,9 @@ pub mod access_control;
 pub mod spl;
 
 pub use dlp_api;
-pub use dlp_api::dlp::args::CallHandlerArgs;
-pub use dlp_api::dlp::pda;
-pub use dlp_api::dlp::{
+pub use dlp_api::args::CallHandlerArgs;
+pub use dlp_api::pda;
+pub use dlp_api::{
     commit_record_seeds_from_delegated_account, commit_state_seeds_from_delegated_account,
     delegate_buffer_seeds_from_delegated_account, delegation_metadata_seeds_from_delegated_account,
     delegation_record_seeds_from_delegated_account, ephemeral_balance_seeds_from_payer,

--- a/rust/sdk/src/spl/builders/delegate_ephemeral_ata.rs
+++ b/rust/sdk/src/spl/builders/delegate_ephemeral_ata.rs
@@ -1,4 +1,4 @@
-use dlp_api::dlp::pda::{
+use dlp_api::pda::{
     delegate_buffer_pda_from_delegated_account_and_owner_program,
     delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
 };

--- a/rust/sdk/src/spl/builders/delegate_ephemeral_ata_permission.rs
+++ b/rust/sdk/src/spl/builders/delegate_ephemeral_ata_permission.rs
@@ -1,4 +1,4 @@
-use dlp_api::dlp::pda::{
+use dlp_api::pda::{
     delegate_buffer_pda_from_delegated_account_and_owner_program,
     delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
 };

--- a/rust/tests/spl_test.rs
+++ b/rust/tests/spl_test.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod tests {
-    use dlp_api::dlp::{
+    use dlp_api::{
         consts::DELEGATION_PROGRAM_ID,
         pda::{
             delegate_buffer_pda_from_delegated_account_and_owner_program,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module paths and dependency references for code organization.

* **Chores**
  * Updated magicblock delegation program API dependency to latest revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->