### PR TITLE
docs(fix): preserve SendOptions in sendTransaction for legacy transactions

### DIFF
--- a/ts/web3js/src/magic-router.ts
+++ b/ts/web3js/src/magic-router.ts
@@ -144,21 +144,27 @@ export class ConnectionMagicRouter extends Connection {
     signersOrOptions?: Signer[] | SendOptions,
     options?: SendOptions,
   ): Promise<TransactionSignature> {
-    // ✅ Implementation goes here
-    // You can check the type dynamically:
     if (transaction instanceof Transaction) {
-      // Legacy
+      // Legacy: mirror @solana/web3.js overloads - second arg may be Signer[] or SendOptions.
       const latestBlockhash =
         await this.getLatestBlockhashForTransaction(transaction);
       transaction.recentBlockhash = latestBlockhash.blockhash;
       transaction.lastValidBlockHeight = latestBlockhash.lastValidBlockHeight;
-
+      
+      let sendOptions: SendOptions | undefined;
       if (Array.isArray(signersOrOptions)) {
-        transaction.sign(...signersOrOptions);
+        if (signersOrOptions.length > 0) {
+          transaction.sign(...signersOrOptions);
+        }
+        sendOptions = options;
+      } else {
+        // e.g. sendTransaction(tx, { skipPreflight: true })
+        sendOptions =
+          options !== undefined ? options : signersOrOptions as SendOptions | undefined;
       }
 
       const wireTx = transaction.serialize();
-      return this.sendRawTransaction(wireTx, options);
+      return this.sendRawTransaction(wireTx, sendOptions);
     } else {
       // VersionedTransaction
       return super.sendTransaction(


### PR DESCRIPTION
Previously, `ConnectionMagicRouter.sendTransaction()` silently ignored SendOptions  (such as `skipPreflight`, `maxRetries`, `minContextSlot`) when the second argument  was passed as options instead of signers.  

This PR fixes the behavior by:  
- Detecting whether the second argument is an array of Signers or SendOptions.  
- Applying signers to the transaction if provided.  
- Passing the correct SendOptions to `sendRawTransaction()`, whether provided as  the second or third argument.  
- Preserving support for VersionedTransaction via `super.sendTransaction()`.  

All legacy and versioned transaction flows are now consistent with  @solana/web3.js expectations.  

Additionally, the changes make it easier to send transactions using either:
1. `sendTransaction(tx, signers)`  
2. `sendTransaction(tx, options)`  
3. `sendTransaction(tx, signers, options)` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction signing logic to only sign when signers are provided, preventing unnecessary signing operations.
  * Improved transaction options handling to correctly prioritize user-provided options throughout the serialization and transmission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->