### PR TITLE
fix: inconsistent Permission serialization/deserialization format

### DIFF
--- a/rust/pinocchio/src/acl/types.rs
+++ b/rust/pinocchio/src/acl/types.rs
@@ -149,6 +149,8 @@ pub struct Member {
 
 pub const MAX_MEMBERS_COUNT: usize = 32;
 pub const MAX_MEMBER_SIZE: usize = size_of::<u8>() + size_of::<Address>(); // flags + address = 33 bytes
+
+const _: () = assert!(core::mem::size_of::<Member>() == MAX_MEMBER_SIZE);
 pub const MAX_MEMBERS_ARGS_SIZE: usize = size_of::<u8>() // option flag
      + size_of::<u32>() // count
      + MAX_MEMBERS_COUNT * MAX_MEMBER_SIZE; // up to 32 members

--- a/rust/pinocchio/src/acl/types.rs
+++ b/rust/pinocchio/src/acl/types.rs
@@ -12,15 +12,12 @@ pub struct Permission<'a> {
 impl<'a> Permission<'a> {
     /// Calculate the exact size needed to serialize this Permission
     pub fn serialized_size(&self) -> usize {
-        // discriminator (1) + bump (1) + address (32) = 34 bytes
-        let mut size = 34;
+        // discriminator (1) + bump (1) + address (32) = 34
+        // + 1 byte option flag
+        let mut size = 34 + 1;
 
-        // If members exist: member_count (4) + members data
         if let Some(members) = self.members {
             size += 4 + members.len() * MAX_MEMBER_SIZE;
-        } else {
-            // If no members: just the member count (0)
-            size += 4;
         }
 
         size
@@ -28,52 +25,67 @@ impl<'a> Permission<'a> {
 
     /// Deserialize Permission from a data slice
     pub fn try_from_slice(data: &'a [u8]) -> Result<Self, ProgramError> {
-        if data.len() < 38 {
-            // discriminator (1) + bump (1) + address (32) + member_count (4)
+        // minimum: 34 (base) + 1 (option)
+        if data.len() < 35 {
             return Err(ProgramError::InvalidAccountData);
         }
 
         let discriminator = data[0];
         let bump = data[1];
+
         let permissioned_account =
             Address::try_from(&data[2..34]).map_err(|_| ProgramError::InvalidAccountData)?;
 
-        // Check if there are members
-        let members_exists = data[34] == 1;
-        let members = if members_exists {
-            let member_count_bytes: [u8; 4] = data[35..39]
-                .try_into()
-                .map_err(|_| ProgramError::InvalidAccountData)?;
-            let member_count = u32::from_le_bytes(member_count_bytes) as usize;
+        let members_flag = data[34];
 
-            Some(if member_count == 0 {
-                &[]
-            } else {
+        let members = match members_flag {
+            0 => None,
+            1 => {
+                // need at least count
+                if data.len() < 39 {
+                    return Err(ProgramError::InvalidAccountData);
+                }
+
+                let member_count_bytes: [u8; 4] = data[35..39]
+                    .try_into()
+                    .map_err(|_| ProgramError::InvalidAccountData)?;
+
+                let member_count = u32::from_le_bytes(member_count_bytes) as usize;
+
                 if member_count > MAX_MEMBERS_COUNT {
                     return Err(ProgramError::InvalidAccountData);
                 }
-                let members_start: usize = 39;
-                let members_len = member_count
-                    .checked_mul(MAX_MEMBER_SIZE)
-                    .ok_or(ProgramError::InvalidAccountData)?;
-                let members_end = members_start
-                    .checked_add(members_len)
-                    .ok_or(ProgramError::InvalidAccountData)?;
-                if members_end > data.len() {
-                    return Err(ProgramError::InvalidAccountData);
-                }
 
-                let members_data = &data[members_start..members_end];
-                let members_slice = unsafe {
-                    core::slice::from_raw_parts(
-                        members_data.as_ptr() as *const Member,
-                        member_count,
-                    )
-                };
-                members_slice
-            })
-        } else {
-            None
+                if member_count == 0 {
+                    Some(&[])
+                } else {
+                    let members_start = 39;
+
+                    let members_len = member_count
+                        .checked_mul(MAX_MEMBER_SIZE)
+                        .ok_or(ProgramError::InvalidAccountData)?;
+
+                    let members_end = members_start
+                        .checked_add(members_len)
+                        .ok_or(ProgramError::InvalidAccountData)?;
+
+                    if members_end > data.len() {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+
+                    let members_data = &data[members_start..members_end];
+
+                    let members_slice = unsafe {
+                        core::slice::from_raw_parts(
+                            members_data.as_ptr() as *const Member,
+                            member_count,
+                        )
+                    };
+
+                    Some(members_slice)
+                }
+            }
+            _ => return Err(ProgramError::InvalidAccountData),
         };
 
         Ok(Permission {
@@ -87,33 +99,40 @@ impl<'a> Permission<'a> {
     /// Serialize Permission to a mutable byte slice
     pub fn try_to_slice<'b>(&self, data: &'b mut [u8]) -> Result<&'b [u8], ProgramError> {
         let required_size = self.serialized_size();
+
         if data.len() < required_size {
             return Err(ProgramError::AccountDataTooSmall);
         }
 
-        // Write discriminator and bump
+        // base fields
         data[0] = self.discriminator;
         data[1] = self.bump;
-
-        // Write permissioned_account
         data[2..34].copy_from_slice(self.permissioned_account.as_ref());
 
-        // Write members
-        let member_count = self.members.map(|m| m.len()).unwrap_or(0);
-        data[34..38].copy_from_slice(&(member_count as u32).to_le_bytes());
+        let mut offset = 34;
 
-        let mut offset = 38;
-
-        // Serialize members if present
-        if let Some(members) = self.members {
-            for member in members {
-                // Flags (1 byte)
-                data[offset] = member.flags.as_u8();
+        match self.members {
+            None => {
+                data[offset] = 0;
+                offset += 1;
+            }
+            Some(members) => {
+                data[offset] = 1;
                 offset += 1;
 
-                // Address (32 bytes)
-                data[offset..offset + 32].copy_from_slice(member.pubkey.as_ref());
-                offset += 32;
+                let member_count = members.len();
+                data[offset..offset + 4]
+                    .copy_from_slice(&(member_count as u32).to_le_bytes());
+                offset += 4;
+
+                for member in members {
+                    data[offset] = member.flags.as_u8();
+                    offset += 1;
+
+                    data[offset..offset + 32]
+                        .copy_from_slice(member.pubkey.as_ref());
+                    offset += 32;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes an inconsistency between `Permission::try_from_slice` and `Permission::try_to_slice` that caused an invalid wire format and broken round-trip serialization.

## Problem

Previously:
- `try_from_slice` expected an option flag at `data[34]` and read `member_count` from `data[35..39]`
- `try_to_slice` wrote `member_count` directly at `data[34..38]` and did not include any option flag

This mismatch resulted in:
- Broken round-trip serialization (serialize → deserialize ≠ original)
- Ambiguity between `None` and `Some([])`
- Potential panic when deserializing short buffers with `data[34] == 1`

## Solution

Unified the wire format across:
- `serialized_size`
- `try_from_slice`
- `try_to_slice`

New layout:

[0]      discriminator  
[1]      bump  
[2..34]  permissioned_account  
[34]     members option flag (0 = None, 1 = Some)  
[35..39] member_count (if Some)  
[39..]   members data  

Key changes:
- Added explicit option flag for `members`
- Fixed offset alignment between serialization and deserialization
- Added strict validation for option flag values (only 0 or 1)
- Added bounds checks to prevent out-of-bounds reads

## Result

- Correct round-trip serialization
- Proper distinction between `None` and `Some([])`
- Eliminated potential panic during deserialization
- Consistent and predictable wire format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission data serialization and validation to correctly handle optional member data via an explicit presence flag.
  * Rejects malformed or inconsistent member counts and flag values to prevent invalid data.
  * Enforces member size limits at build time to avoid runtime inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->