### PR TITLE
docs: replace `connection.fullySignTransaction(...)` && remove the redundant `@param validatorIdentity`

### DIFF
--- a/ts/kit/src/access-control/verify.ts
+++ b/ts/kit/src/access-control/verify.ts
@@ -51,7 +51,6 @@ export async function verifyTeeRpcIntegrity(rpcUrl: string): Promise<boolean> {
 /**
  * Verify the integrity of the RPC
  * @param rpcUrl - The URL of the RPC server
- * @param validatorIdentity - The expected identity of the validator
  * @returns True if the quote is valid, false otherwise
  */
 export async function verifyTeeIntegrity(rpcUrl: string): Promise<boolean> {

--- a/ts/kit/src/connection.ts
+++ b/ts/kit/src/connection.ts
@@ -273,8 +273,8 @@ export class Connection {
    * const tx = await connection.prepareTransactionWithLatestBlockhash(transaction);
    * const partiallySigned = await connection.partiallySignTransaction([signer1, signer2], tx);
    *
-   * // Later, another party can add their signature:
-   * const fullySigned = await connection.fullySignTransaction([signer3], partiallySigned);
+   * // Another signer can add a signature by calling this method again:
+   * const signedAgain = await connection.partiallySignTransaction([signer3], partiallySigned);
    * ```
    */
   public async partiallySignTransaction(


### PR DESCRIPTION
1. In the JSDoc example, I replaced the non-existent `connection.fullySignTransaction(...)` with the actual `supported flow` by re-calling `connection.partiallySignTransaction(...)`.

2. I removed the redundant `@param validatorIdentity`, which is not present in the signature of `verifyTeeIntegrity(rpcUrl: string)`.

The documentation now reflects the actual API; otherwise, the user’s copy-paste would break immediately.
For connection.ts, we chose not to “remove the example” but to show a working path using the methods that actually exist in the package.
For verify.ts, we removed the false expectation from the IDE/docs so that the signature and JSDoc would be fully consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified TEE integrity verification function documentation to ensure accuracy.
  * Updated transaction signing examples to reflect current API usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->