### PR TITLE
docs: fix broken imports and add syntax highlighting in SDK READMEs

### DIFF
--- a/ts/kit/README.md
+++ b/ts/kit/README.md
@@ -14,7 +14,7 @@ npm install @magicblock-labs/ephemeral-rollups-kit
 yarn add @magicblock-labs/ephemeral-rollups-kit
 ```
 ## Usage (basic)
-
+```ts
 import { Connection } from "@magicblock-labs/ephemeral-rollups-kit";
 
 // See full examples and docs in the Quickstart link above.

--- a/ts/kit/README.md
+++ b/ts/kit/README.md
@@ -6,14 +6,19 @@ Quickstart and integration guide:
 https://docs.magicblock.gg
 
 ## Install
+
 ```bash
 npm install @magicblock-labs/ephemeral-rollups-kit
 ```
+
 # or
+
 ```bash
 yarn add @magicblock-labs/ephemeral-rollups-kit
 ```
+
 ## Usage (basic)
+
 ```ts
 import { Connection } from "@magicblock-labs/ephemeral-rollups-kit";
 

--- a/ts/web3js/README.md
+++ b/ts/web3js/README.md
@@ -6,14 +6,19 @@ Quickstart and integration guide:
 https://docs.magicblock.gg
 
 ## Install
+
 ```bash
 npm install @magicblock-labs/ephemeral-rollups-sdk
 ```
+
 # or
+
 ```bash
 yarn add @magicblock-labs/ephemeral-rollups-sdk
 ```
+
 ## Usage (basic)
+
 ```ts
 import { ConnectionMagicRouter } from "@magicblock-labs/ephemeral-rollups-sdk";
 

--- a/ts/web3js/README.md
+++ b/ts/web3js/README.md
@@ -15,7 +15,7 @@ yarn add @magicblock-labs/ephemeral-rollups-sdk
 ```
 ## Usage (basic)
 ```ts
-import { MagicRouter } from "@magicblock-labs/ephemeral-rollups-sdk";
+import { ConnectionMagicRouter } from "@magicblock-labs/ephemeral-rollups-sdk";
 
 // See full examples and docs in the Quickstart link above.
 ```

--- a/ts/web3js/README.md
+++ b/ts/web3js/README.md
@@ -1,20 +1,21 @@
 # @magicblock-labs/ephemeral-rollups-sdk
 
-TypeScript helpers for preparing and routing transactions to Ephemeral Rollups on Solana with @solana/web3.js.
+TypeScript helpers for preparing and routing transactions to Ephemeral Rollups on Solana with `@solana/web3.js`.
 
 Quickstart and integration guide:
 https://docs.magicblock.gg
 
 ## Install
-
+```bash
 npm install @magicblock-labs/ephemeral-rollups-sdk
-
+```
 # or
-
+```bash
 yarn add @magicblock-labs/ephemeral-rollups-sdk
-
+```
 ## Usage (basic)
-
+```ts
 import { MagicRouter } from "@magicblock-labs/ephemeral-rollups-sdk";
 
 // See full examples and docs in the Quickstart link above.
+```


### PR DESCRIPTION
Fix non‑exported `MagicRouter` import:
The README examples imported `MagicRouter`, but the package only exports `ConnectionMagicRouter`. Users copying the snippet would get TypeScript errors (has no exported member 'MagicRouter').

Fix: Replace `MagicRouter` with `ConnectionMagicRouter` to match the actual API.

****

The `ts/web3js/README.md` and `ts/sdk/README.md` files used inconsistent formatting without Markdown code fences. Following the pattern already present in `ts/kit/README.md`, I added:
- `bash` blocks around install commands
- `ts` blocks around usage imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced code formatting in kit and web3js documentation with improved code fence syntax highlighting
  * Updated web3js import example references and installation command formatting for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->