### PR TITLE
feat: export NoVec

### DIFF
--- a/rust/pinocchio/src/intent_bundle/mod.rs
+++ b/rust/pinocchio/src/intent_bundle/mod.rs
@@ -10,7 +10,7 @@ use solana_address::Address;
 mod args;
 mod commit;
 mod commit_and_undelegate;
-mod no_vec;
+pub mod no_vec;
 mod serialize;
 pub mod types;
 

--- a/rust/pinocchio/src/lib.rs
+++ b/rust/pinocchio/src/lib.rs
@@ -16,6 +16,7 @@ pub mod utils;
 use pinocchio::Address;
 
 pub use consts::DELEGATION_PROGRAM_ID as ID;
+pub use intent_bundle::no_vec;
 
 /// Returns a reference to the delegation program ID.
 pub fn id() -> &'static Address {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made the `no_vec` module publicly accessible through updated module visibility and crate-level re-exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->