### PR TITLE
release: 0.10.5

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-pinocchio"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "bincode 1.3.3",
  "bincode 2.0.1",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anchor-lang",
  "base64ct",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-action"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral-accounts"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "magic-resolver"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "base64 0.12.3",
  "bincode 1.3.3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.4"
+version = "0.10.5"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 edition = "2021"
 license = "MIT"
@@ -24,12 +24,12 @@ readme = "README.md"
 keywords = ["solana", "crypto", "delegation", "ephemeral-rollups", "magicblock"]
 
 [workspace.dependencies]
-ephemeral-rollups-sdk = { path = "sdk", version = "=0.10.4" }
-ephemeral-rollups-sdk-attribute-ephemeral = { path = "ephemeral", version = "=0.10.4" }
-ephemeral-rollups-sdk-attribute-ephemeral-accounts = { path = "ephemeral-accounts-attribute", version = "=0.10.4" }
-ephemeral-rollups-sdk-attribute-delegate = { path = "delegate", version = "=0.10.4" }
-ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = "=0.10.4" }
-ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = "=0.10.4" }
+ephemeral-rollups-sdk = { path = "sdk", version = "=0.10.5" }
+ephemeral-rollups-sdk-attribute-ephemeral = { path = "ephemeral", version = "=0.10.5" }
+ephemeral-rollups-sdk-attribute-ephemeral-accounts = { path = "ephemeral-accounts-attribute", version = "=0.10.5" }
+ephemeral-rollups-sdk-attribute-delegate = { path = "delegate", version = "=0.10.5" }
+ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = "=0.10.5" }
+ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = "=0.10.5" }
 
 
 # Magicblock

--- a/ts/kit/package.json
+++ b/ts/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-rollups-kit",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": "MagicBlock Labs",
   "license": "MIT",
   "publishConfig": {

--- a/ts/web3js/package.json
+++ b/ts/web3js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-rollups-sdk",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": "MagicBlock Labs",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all package versions to 0.10.5 across the monorepo, including Rust workspace dependencies and TypeScript packages (kit and web3js). This ensures consistent versioning across all published modules and internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->