### PR TITLE
chore: make sdk backward compatible

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2211,12 +2211,10 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a413fd0a3ce67bba8c31b681f37088a897d47a3c39fd0d9303725882898ad78"
+version = "0.3.0"
 dependencies = [
  "bincode 1.3.3",
- "borsh 1.6.0",
+ "borsh 0.10.4",
  "bytemuck",
  "const-crypto",
  "libsodium-rs",
@@ -2234,7 +2232,7 @@ dependencies = [
  "solana-sha256-hasher 3.1.0",
  "static_assertions",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2212,9 +2212,11 @@ dependencies = [
 [[package]]
 name = "magicblock-delegation-program-api"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8447309107c033ed0b5416c485b64f281a2e49c28adee03d14899fe58301187"
 dependencies = [
  "bincode 1.3.3",
- "borsh 0.10.4",
+ "borsh 1.6.0",
  "bytemuck",
  "const-crypto",
  "libsodium-rs",
@@ -2232,7 +2234,7 @@ dependencies = [
  "solana-sha256-hasher 3.1.0",
  "static_assertions",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,8 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 
 
 # Magicblock
-magicblock-delegation-program-api = { version = "0.1.1", default-features = false }
+#magicblock-delegation-program-api = { version = "0.1.1", default-features = false }
+magicblock-delegation-program-api = { path = "/Users/snawaz/projects/mb/delegation-program/dlp-api", default-features = false }
 magicblock-magic-program-api = { version = "0.8.5", default-features = false }
 
 ## External crates

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,8 +33,8 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 
 
 # Magicblock
-#magicblock-delegation-program-api = { version = "0.1.1", default-features = false }
-magicblock-delegation-program-api = { path = "/Users/snawaz/projects/mb/delegation-program/dlp-api", default-features = false }
+magicblock-delegation-program-api = { version = "0.3.0", default-features = false }
+#magicblock-delegation-program-api = { path = "/Users/snawaz/projects/mb/delegation-program/dlp-api", default-features = false }
 magicblock-magic-program-api = { version = "0.8.5", default-features = false }
 
 ## External crates
@@ -96,7 +96,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_with = { version = "3.16" }
 serde_json = { version = "1.0" }
 json = { package = "sonic-rs", version = "0.3" }
-borsh = "1.5.7"
+borsh_1_6 = { package = "borsh", version = "=1.6" }
 humantime = "2.1"
 
 # codec

--- a/rust/pinocchio/Cargo.toml
+++ b/rust/pinocchio/Cargo.toml
@@ -25,7 +25,7 @@ bincode = { version = "2.0.1", default-features = false, features = [
     "derive",
 ]}
 magicblock-delegation-program-api = { workspace = true, optional = true }
-borsh = { workspace = true, optional = true }
+borsh_1_6 = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode1 = { package = "bincode", version = "1.3" }
@@ -37,7 +37,7 @@ solana-instruction = { workspace = true }
 [features]
 default = []
 delegation-actions = [
-    "borsh",
+    "borsh_1_6",
     "pinocchio/alloc",
     "pinocchio/cpi",
     "magicblock-delegation-program-api",

--- a/rust/resolver/Cargo.toml
+++ b/rust/resolver/Cargo.toml
@@ -39,7 +39,7 @@ solana-program = { workspace = true }
 serde = { workspace = true, default-features = true }
 json = { workspace = true }
 humantime = { workspace = true }
-borsh = { workspace = true } 
+borsh_1_6 = { workspace = true } 
 
 # codec
 base64 = { workspace = true }

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -41,7 +41,7 @@ serde = []
 
 [dependencies]
 anchor-lang = { workspace = true, optional = true }
-borsh = { workspace = true }
+borsh_1_6 = { workspace = true }
 bincode = { workspace = true }
 ephemeral-rollups-sdk-attribute-delegate = { workspace = true }
 ephemeral-rollups-sdk-attribute-ephemeral = { workspace = true }

--- a/rust/sdk/src/access_control/instructions/close_permission.rs
+++ b/rust/sdk/src/access_control/instructions/close_permission.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::access_control::structs::Permission;
 use crate::consts::PERMISSION_PROGRAM_ID;

--- a/rust/sdk/src/access_control/instructions/commit_and_undelegate_permission.rs
+++ b/rust/sdk/src/access_control/instructions/commit_and_undelegate_permission.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::access_control::structs::Permission;
 use crate::consts::PERMISSION_PROGRAM_ID;

--- a/rust/sdk/src/access_control/instructions/commit_permission.rs
+++ b/rust/sdk/src/access_control/instructions/commit_permission.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::access_control::structs::Permission;
 use crate::consts::PERMISSION_PROGRAM_ID;

--- a/rust/sdk/src/access_control/instructions/create_permission.rs
+++ b/rust/sdk/src/access_control/instructions/create_permission.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::access_control::structs::MembersArgs;
 use crate::access_control::structs::Permission;

--- a/rust/sdk/src/access_control/instructions/delegate_permission.rs
+++ b/rust/sdk/src/access_control/instructions/delegate_permission.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::consts::PERMISSION_PROGRAM_ID;
 use crate::solana_compat::solana::{

--- a/rust/sdk/src/access_control/instructions/undelegate_permission.rs
+++ b/rust/sdk/src/access_control/instructions/undelegate_permission.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::access_control::structs::UndelegateArgs;
 use crate::consts::PERMISSION_PROGRAM_ID;

--- a/rust/sdk/src/access_control/instructions/update_permission.rs
+++ b/rust/sdk/src/access_control/instructions/update_permission.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::access_control::structs::MembersArgs;
 use crate::access_control::structs::Permission;

--- a/rust/sdk/src/access_control/structs/member.rs
+++ b/rust/sdk/src/access_control/structs/member.rs
@@ -1,21 +1,15 @@
-#[cfg(feature = "anchor")]
-use anchor_lang::prelude::*;
-
-#[cfg(not(feature = "anchor"))]
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 use crate::solana_compat::solana::Pubkey;
 
-#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
-#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[derive(BorshSerialize, BorshDeserialize)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Member {
     pub flags: u8,
     pub pubkey: Pubkey,
 }
 
-#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
-#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[derive(BorshSerialize, BorshDeserialize)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MembersArgs {
     pub members: Option<Vec<Member>>,

--- a/rust/sdk/src/access_control/structs/permission.rs
+++ b/rust/sdk/src/access_control/structs/permission.rs
@@ -2,16 +2,11 @@ use crate::access_control::structs::Member;
 use crate::consts::PERMISSION_PROGRAM_ID;
 use crate::solana_compat::solana::Pubkey;
 
-#[cfg(feature = "anchor")]
-use anchor_lang::prelude::*;
-
-#[cfg(not(feature = "anchor"))]
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 pub const PERMISSION_SEED: &[u8] = b"permission:";
 
-#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
-#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[derive(BorshSerialize, BorshDeserialize)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Permission {
     pub discriminator: u8,

--- a/rust/sdk/src/access_control/structs/undelegate_args.rs
+++ b/rust/sdk/src/access_control/structs/undelegate_args.rs
@@ -1,11 +1,6 @@
-#[cfg(feature = "anchor")]
-use anchor_lang::prelude::*;
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
-#[cfg(not(feature = "anchor"))]
-use borsh::{BorshDeserialize, BorshSerialize};
-
-#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
-#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[derive(BorshSerialize, BorshDeserialize)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UndelegateArgs {
     pub pda_seeds: Vec<Vec<u8>>,

--- a/rust/sdk/src/cpi.rs
+++ b/rust/sdk/src/cpi.rs
@@ -1,6 +1,6 @@
 use crate::types::DelegateAccountArgs;
 use crate::utils::{close_pda_with_system_transfer, create_pda, seeds_with_bump};
-use borsh::{to_vec, BorshSerialize};
+use borsh_1_6::{self as borsh, to_vec, BorshSerialize};
 use dlp_api::args::{DelegateArgs, DelegateWithActionsArgs, PostDelegationActions};
 use dlp_api::delegate_buffer_seeds_from_delegated_account;
 use dlp_api::discriminator::DlpDiscriminator;

--- a/rust/sdk/src/types.rs
+++ b/rust/sdk/src/types.rs
@@ -1,5 +1,5 @@
 use crate::solana_compat::solana::Pubkey;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_6::{self as borsh, BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct DelegateAccountArgs {


### PR DESCRIPTION
chore: make sdk backward compatible

Use borsh_1_6 and fix the inconsistent usage of 'anchor' feature flag inside access-control module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated Borsh serialization library to version 1.6 across all components.
  * Updated delegation program API dependency to version 0.3.0.

* **Refactor**
  * Simplified serialization trait handling by standardizing on Borsh serialization (removed feature-dependent Anchor serialization fallback).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->