### PR TITLE
chore: make sdk backward compatible

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1154,7 +1154,7 @@ version = "0.10.9"
 dependencies = [
  "bincode 1.3.3",
  "bincode 2.0.1",
- "borsh 1.6.0",
+ "borsh 0.10.4",
  "ephemeral-rollups-sdk",
  "magicblock-delegation-program-api",
  "magicblock-magic-program-api",
@@ -1173,7 +1173,7 @@ dependencies = [
  "anchor-lang",
  "base64ct",
  "bincode 1.3.3",
- "borsh 1.6.0",
+ "borsh 0.10.4",
  "ephemeral-rollups-sdk-attribute-action",
  "ephemeral-rollups-sdk-attribute-commit",
  "ephemeral-rollups-sdk-attribute-delegate",
@@ -2211,12 +2211,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "0.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a413fd0a3ce67bba8c31b681f37088a897d47a3c39fd0d9303725882898ad78"
+checksum = "7c24e2f7c4d2dc7e4d7c0a200f0cfac03e39745e7f5a03d72959f2e5847894b6"
 dependencies = [
  "bincode 1.3.3",
- "borsh 1.6.0",
+ "borsh 0.10.4",
  "bytemuck",
  "const-crypto",
  "libsodium-rs",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 
 
 # Magicblock
-magicblock-delegation-program-api = { version = "0.1.1", default-features = false }
+magicblock-delegation-program-api = { version = "2.0.0", default-features = false }
 magicblock-magic-program-api = { version = "0.8.5", default-features = false }
 
 ## External crates

--- a/rust/pinocchio/Cargo.toml
+++ b/rust/pinocchio/Cargo.toml
@@ -25,7 +25,7 @@ bincode = { version = "2.0.1", default-features = false, features = [
     "derive",
 ]}
 magicblock-delegation-program-api = { workspace = true, optional = true }
-borsh = { workspace = true, optional = true }
+borsh = { version = "0.10.4", optional = true }
 
 [dev-dependencies]
 bincode1 = { package = "bincode", version = "1.3" }

--- a/rust/pinocchio/src/instruction/delegate_with_actions.rs
+++ b/rust/pinocchio/src/instruction/delegate_with_actions.rs
@@ -11,7 +11,7 @@ use crate::pda::find_program_address;
 use crate::types::DelegateAccountArgs;
 use crate::utils::{cpi_delegate_with_actions, make_seed_buf};
 use crate::{consts::BUFFER, types::DelegateConfig, utils::close_pda_acc};
-pub use dlp_api::dlp::{
+pub use dlp_api::{
     args::{
         EncryptedBuffer, MaybeEncryptedAccountMeta, MaybeEncryptedInstruction,
         MaybeEncryptedIxData, MaybeEncryptedPubkey, PostDelegationActions,

--- a/rust/pinocchio/src/utils.rs
+++ b/rust/pinocchio/src/utils.rs
@@ -173,11 +173,11 @@ fn cpi_delegate_with_discriminator(
 #[cfg(feature = "delegation-actions")]
 pub fn serialize_delegate_with_actions_data(
     delegate_args: DelegateAccountArgs,
-    actions: dlp_api::dlp::args::PostDelegationActions,
+    actions: dlp_api::args::PostDelegationActions,
 ) -> Result<alloc::vec::Vec<u8>, ProgramError> {
     use alloc::vec::Vec;
-    use dlp_api::dlp::args::{DelegateArgs, DelegateWithActionsArgs};
-    use dlp_api::dlp::discriminator::DlpDiscriminator;
+    use dlp_api::args::{DelegateArgs, DelegateWithActionsArgs};
+    use dlp_api::discriminator::DlpDiscriminator;
     use solana_program::pubkey::Pubkey;
 
     let seeds_vec: Vec<Vec<u8>> = delegate_args.seeds.iter().map(|s| s.to_vec()).collect();
@@ -207,7 +207,7 @@ pub fn cpi_delegate_with_actions(
     delegation_metadata: &AccountView,
     system_program: &AccountView,
     delegate_args: DelegateAccountArgs,
-    actions: dlp_api::dlp::args::PostDelegationActions,
+    actions: dlp_api::args::PostDelegationActions,
     action_signer_accounts: &[&AccountView],
     signer_seeds: Signer<'_, '_>,
 ) -> Result<(), ProgramError> {

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -41,7 +41,7 @@ serde = []
 
 [dependencies]
 anchor-lang = { workspace = true, optional = true }
-borsh = { workspace = true }
+borsh = "0.10.4"
 bincode = { workspace = true }
 ephemeral-rollups-sdk-attribute-delegate = { workspace = true }
 ephemeral-rollups-sdk-attribute-ephemeral = { workspace = true }

--- a/rust/sdk/src/cpi.rs
+++ b/rust/sdk/src/cpi.rs
@@ -1,6 +1,6 @@
 use crate::types::DelegateAccountArgs;
 use crate::utils::{close_pda_with_system_transfer, create_pda, seeds_with_bump};
-use borsh::{to_vec, BorshSerialize};
+use borsh::BorshSerialize;
 use dlp_api::args::{DelegateArgs, DelegateWithActionsArgs, PostDelegationActions};
 use dlp_api::delegate_buffer_seeds_from_delegated_account;
 use dlp_api::discriminator::DlpDiscriminator;
@@ -335,7 +335,7 @@ pub fn cpi_delegate_with_actions<'a, 'info>(
     action_signer_infos: &'a [&'a AccountInfo<'info>],
 ) -> ProgramResult {
     let mut data = DlpDiscriminator::DelegateWithActions.to_vec();
-    let payload = to_vec(&args).map_err(|_| ProgramError::InvalidInstructionData)?;
+    let payload = borsh::to_vec(&args).map_err(|_| ProgramError::InvalidInstructionData)?;
     data.extend_from_slice(&payload);
 
     let mut accounts = vec![


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workspace and crate dependency versions (including serialization crate) to pinned releases.
* **Refactor**
  * Adjusted internal re-exports and type paths used for delegation-with-actions serialization and CPI calls to align with updated dependencies; no public API behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->