### PR TITLE
feat: lint for PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,12 +67,14 @@ jobs:
         run: |
           npm install
           npm test
+          npm run lint
           npm run build
       - name: npm run build and test web3js
         working-directory: ts/web3js
         run: |
           npm install
           npm test
+          npm run lint
           npm run build
   integration-tests:
     name: Delegation Program Integration Tests (Anchor)

--- a/ts/kit/src/index.ts
+++ b/ts/kit/src/index.ts
@@ -3,5 +3,6 @@ export * from "./pda.js";
 export * from "./utils.js";
 export * from "./resolver.js";
 export * from "./connection.js";
-export * from "./confirmation.js"; export * from "./instructions/index.js";
+export * from "./confirmation.js";
+export * from "./instructions/index.js";
 export * from "./access-control/index.js";

--- a/ts/kit/src/index.ts
+++ b/ts/kit/src/index.ts
@@ -3,6 +3,5 @@ export * from "./pda.js";
 export * from "./utils.js";
 export * from "./resolver.js";
 export * from "./connection.js";
-export * from "./confirmation.js";
-export * from "./instructions/index.js";
+export * from "./confirmation.js"; export * from "./instructions/index.js";
 export * from "./access-control/index.js";


### PR DESCRIPTION
Lint currently only runs on release branches, causing some merged changes to not respect linting, which requires additional commits before releasing a new version