### PR TITLE
fix(kit): mark delegated PDAs writable in commitAndUndelegate

### DIFF
--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -708,7 +708,7 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(instruction.accounts?.[1].role).toBe(AccountRole.WRITABLE);
     });
 
-    it("should include accounts to commit and undelegate as readonly", () => {
+    it("should include accounts to commit and undelegate as writable", () => {
       const accountsToCommitAndUndelegate: Address[] = [
         "11111111111111111111111111111113" as Address,
         "11111111111111111111111111111114" as Address,
@@ -722,10 +722,30 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(instruction.accounts?.[2].address).toBe(
         accountsToCommitAndUndelegate[0],
       );
-      expect(instruction.accounts?.[2].role).toBe(AccountRole.READONLY);
+      expect(instruction.accounts?.[2].role).toBe(AccountRole.WRITABLE);
       expect(instruction.accounts?.[3].address).toBe(
         accountsToCommitAndUndelegate[1],
       );
+      expect(instruction.accounts?.[3].role).toBe(AccountRole.WRITABLE);
+    });
+
+    it("should mark every delegated PDA writable across multiple accounts", () => {
+      const delegatedAccounts: Address[] = [
+        "22222222222222222222222222222222" as Address,
+        "33333333333333333333333333333333" as Address,
+        "44444444444444444444444444444444" as Address,
+      ];
+      const instruction = createCommitAndUndelegateInstruction(
+        mockAddress,
+        delegatedAccounts,
+      );
+
+      expect(instruction.accounts).toHaveLength(5);
+      delegatedAccounts.forEach((_, index) => {
+        expect(instruction.accounts?.[2 + index].role).toBe(
+          AccountRole.WRITABLE,
+        );
+      });
     });
 
     it("should handle single account to commit and undelegate", () => {

--- a/ts/kit/src/instructions/magic-program/scheduleCommitAndUndelegate.ts
+++ b/ts/kit/src/instructions/magic-program/scheduleCommitAndUndelegate.ts
@@ -20,7 +20,7 @@ export function createCommitAndUndelegateInstruction(
     { address: MAGIC_CONTEXT_ID, role: AccountRole.WRITABLE },
     ...accountsToCommitAndUndelegate.map((account) => ({
       address: account,
-      role: AccountRole.READONLY,
+      role: AccountRole.WRITABLE,
     })),
   ] as const;
 


### PR DESCRIPTION
## Summary

  `createCommitAndUndelegateInstruction` in `ts/kit` hard-codes the delegated
  PDA accounts as `AccountRole.READONLY`. Sending the resulting instruction as
  a top-level transaction to an ephemeral rollup fails with
  `instruction modified data of a read-only account`, because the Magic
  Program's `ScheduleCommitAndUndelegate` handler explicitly requires every
  delegated account to be writable.

  ## Root cause

  In [magicblock-validator : programs/magicblock/src/schedule_transactions/process_schedule_commit.rs:174-184](https://github.com/magicblock-labs/magicblock-validator/blob/master/programs/magicblock/src/schedule_transactions/process_schedule_commit.rs#L178):

  ```rust
  if opts.request_undelegation {
      // Must be writable and delegated to avoid double-undelegation
      let is_writable = get_writable_with_idx(transaction_context, idx as u16)?;
      if !is_writable || !is_delegated {
          ic_msg!(
              invoke_context,
              "ScheduleCommit ERR: account {} is required to be writable and delegated in order to be undelegated",
              acc_pubkey
          );
          return Err(InstructionError::ReadonlyDataModified);
      }
  }
```

  The InstructionError::ReadonlyDataModified returned at line 184 is the
  exact variant that the Solana runtime formats to clients as
  instruction modified data of a read-only account. The TS helper hardcoding
  readonly trips this guard directly.

  The Rust CPI helper at rust/sdk/src/ephem/deprecated/v0.rs forwards
  is_writable from the caller's AccountInfo, so Anchor's #[account(mut)]
  produces the right shape and the Rust path works end-to-end. The TS side
  builds raw AccountMeta directly with no caller-forwarding equivalent, so
  the only correct fix is to hardcode WRITABLE — matching what the handler
  requires.

  The sibling createCommitInstruction (commit-only) correctly stays readonly:
  the same handler's commit-only branch (lines 186-193) only checks
  is_delegated, not is_writable, because commit without undelegation does
  not mutate the account inside the ER.

  Changes

  - ts/kit/src/instructions/magic-program/scheduleCommitAndUndelegate.ts:
  AccountRole.READONLY → AccountRole.WRITABLE for every account in
  accountsToCommitAndUndelegate.

  Test plan

  - Flipped the existing "should include accounts to commit and undelegate as readonly" assertion in src/__test__/instructions.test.ts to the
  post-fix invariant (renamed to "...as writable").
  - Added a multi-account test asserting every delegated PDA AccountMeta is
  writable, to catch regressions from future refactors.
  - npm run build && npm test pass locally (120/120).

  Backwards compatibility

  Strictly additive at the runtime level. No caller ever wanted these
  accounts readonly — the resulting transaction cannot succeed against the
  Magic Program. No type signatures change. No callers need updates. Repro
  for anyone wanting to verify: build the instruction in TS, send it
  top-level to any ER validator, observe the error; apply this diff, repeat,
  observe success.

## Related
Companion PR https://github.com/magicblock-labs/ephemeral-rollups-sdk/pull/200  applies the same fix to the `ts/web3js` client. The two packages release independently, so the PRs are independently mergeable, this one does not block or depend on the other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected account access permissions in commit and undelegate operations to ensure affected accounts are properly marked as writable, enabling accurate on-chain transaction processing and validation.

* **Tests**
  * Enhanced test coverage for commit and undelegate operations, introducing new test cases for multiple delegated accounts and comprehensive verification of proper account configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->