### PR TITLE
fix(web3js): mark delegated PDAs writable in commitAndUndelegate

### DIFF
--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -733,7 +733,7 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(instruction.keys[1].isWritable).toBe(true);
     });
 
-    it("should include accounts to commit and undelegate as readonly", () => {
+    it("should include accounts to commit and undelegate as writable", () => {
       const accountsToCommitAndUndelegate = [
         new PublicKey("11111111111111111111111111111113"),
         new PublicKey("11111111111111111111111111111114"),
@@ -748,10 +748,28 @@ describe("Exposed Instructions (web3.js)", () => {
         accountsToCommitAndUndelegate[0].toBase58(),
       );
       expect(instruction.keys[2].isSigner).toBe(false);
-      expect(instruction.keys[2].isWritable).toBe(false);
+      expect(instruction.keys[2].isWritable).toBe(true);
       expect(instruction.keys[3].pubkey.toBase58()).toBe(
         accountsToCommitAndUndelegate[1].toBase58(),
       );
+      expect(instruction.keys[3].isWritable).toBe(true);
+    });
+
+    it("should mark every delegated PDA writable across multiple accounts", () => {
+      const delegatedAccounts = [
+        new PublicKey("11111111111111111111111111111113"),
+        new PublicKey("11111111111111111111111111111114"),
+        new PublicKey("11111111111111111111111111111115"),
+      ];
+      const instruction = createCommitAndUndelegateInstruction(
+        mockPublicKey,
+        delegatedAccounts,
+      );
+
+      expect(instruction.keys).toHaveLength(5);
+      delegatedAccounts.forEach((_, index) => {
+        expect(instruction.keys[2 + index].isWritable).toBe(true);
+      });
     });
 
     it("should handle single account to commit and undelegate", () => {

--- a/ts/web3js/src/instructions/magic-program/scheduleCommitAndUndelegate.ts
+++ b/ts/web3js/src/instructions/magic-program/scheduleCommitAndUndelegate.ts
@@ -20,7 +20,7 @@ export function createCommitAndUndelegateInstruction(
     ...accountsToCommitAndUndelegate.map((account) => ({
       pubkey: account,
       isSigner: false,
-      isWritable: false,
+      isWritable: true,
     })),
   ];
 


### PR DESCRIPTION
  ## Summary

  `createCommitAndUndelegateInstruction` in `ts/web3js` hard-codes the
  delegated PDA `AccountMeta`s as `isWritable: false`. Sending the resulting
  instruction as a top-level transaction to an ephemeral rollup fails with
  `instruction modified data of a read-only account`, because the Magic
  Program's `ScheduleCommitAndUndelegate` handler explicitly requires every
  delegated account to be writable.

  ## Root cause

  In magicblock-validator : [programs/magicblock/src/schedule_transactions/process_schedule_commit.rs:174-184](https://github.com/magicblock-labs/magicblock-validator/blob/master/programs/magicblock/src/schedule_transactions/process_schedule_commit.rs#L178) :

  ```rust
  if opts.request_undelegation {
      // Must be writable and delegated to avoid double-undelegation
      let is_writable = get_writable_with_idx(transaction_context, idx as u16)?;
      if !is_writable || !is_delegated {
          ic_msg!(
              invoke_context,
              "ScheduleCommit ERR: account {} is required to be writable and delegated in order to be undelegated",
              acc_pubkey
          );
          return Err(InstructionError::ReadonlyDataModified);
      }
  }
```

  The InstructionError::ReadonlyDataModified returned at line 184 is the
  exact variant that the Solana runtime formats to clients as
  instruction modified data of a read-only account. The TS helper hardcoding
  isWritable: false trips this guard directly.

  The Rust CPI helper at rust/sdk/src/ephem/deprecated/v0.rs forwards
  is_writable from the caller's AccountInfo, so Anchor's #[account(mut)]
  produces the right shape and the Rust path works end-to-end. The TS side
  builds raw AccountMeta directly with no caller-forwarding equivalent, so
  the only correct fix is to hardcode isWritable: true — matching what the
  handler requires.

  The sibling createCommitInstruction (commit-only) correctly stays readonly:
  the same handler's commit-only branch (lines 186-193) only checks
  is_delegated, not is_writable, because commit without undelegation does
  not mutate the account inside the ER.

 Changes

  - ts/web3js/src/instructions/magic-program/scheduleCommitAndUndelegate.ts:
  isWritable: false → isWritable: true for every account in
  accountsToCommitAndUndelegate.

  Test plan

  - Flipped the existing "should include accounts to commit and undelegate as readonly" assertion in src/__test__/instructions.test.ts to the
  post-fix invariant (renamed to "...as writable").
  - Added a multi-account test asserting every delegated PDA AccountMeta is
  writable, to catch regressions from future refactors.
  - npm run build && npm test pass locally (120/120).

  Backwards compatibility

  Strictly additive at the runtime level. No caller ever wanted these
  accounts readonly — the resulting transaction cannot succeed against the
  Magic Program. No type signatures change. No callers need updates. Repro
  for anyone wanting to verify: build the instruction in TS, send it
  top-level to any ER validator, observe the error; apply this diff, repeat,
  observe success.


## Related

 Companion PR https://github.com/magicblock-labs/ephemeral-rollups-sdk/pull/199 applies the same fix to the `ts/kit` client. The two  packages release independently, so the PRs are independently mergeable, this one does not block or depend on the other.