### PR TITLE
make validator account optional in delegate_permission instruction

### DIFF
--- a/rust/pinocchio/src/acl/instruction/delegate_permission.rs
+++ b/rust/pinocchio/src/acl/instruction/delegate_permission.rs
@@ -197,6 +197,67 @@ impl<'a> DelegatePermissionCpiBuilder<'a> {
         validator: &'a AccountView,
         permission_program: &'a Address,
     ) -> Self {
+        Self::new_with_optional_validator(
+            payer,
+            authority,
+            permissioned_account,
+            permission,
+            system_program,
+            owner_program,
+            delegation_buffer,
+            delegation_record,
+            delegation_metadata,
+            delegation_program,
+            Some(validator),
+            permission_program,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_without_validator(
+        payer: &'a AccountView,
+        authority: &'a AccountView,
+        permissioned_account: &'a AccountView,
+        permission: &'a AccountView,
+        system_program: &'a AccountView,
+        owner_program: &'a AccountView,
+        delegation_buffer: &'a AccountView,
+        delegation_record: &'a AccountView,
+        delegation_metadata: &'a AccountView,
+        delegation_program: &'a AccountView,
+        permission_program: &'a Address,
+    ) -> Self {
+        Self::new_with_optional_validator(
+            payer,
+            authority,
+            permissioned_account,
+            permission,
+            system_program,
+            owner_program,
+            delegation_buffer,
+            delegation_record,
+            delegation_metadata,
+            delegation_program,
+            None,
+            permission_program,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_optional_validator(
+        payer: &'a AccountView,
+        authority: &'a AccountView,
+        permissioned_account: &'a AccountView,
+        permission: &'a AccountView,
+        system_program: &'a AccountView,
+        owner_program: &'a AccountView,
+        delegation_buffer: &'a AccountView,
+        delegation_record: &'a AccountView,
+        delegation_metadata: &'a AccountView,
+        delegation_program: &'a AccountView,
+        validator: Option<&'a AccountView>,
+        permission_program: &'a Address,
+    ) -> Self {
         Self {
             payer,
             authority,
@@ -208,7 +269,7 @@ impl<'a> DelegatePermissionCpiBuilder<'a> {
             delegation_record,
             delegation_metadata,
             delegation_program,
-            validator: Some(validator),
+            validator,
             permission_program,
             authority_is_signer: true,
             permissioned_account_is_signer: true,
@@ -228,6 +289,11 @@ impl<'a> DelegatePermissionCpiBuilder<'a> {
 
     pub fn signer_seeds(mut self, signer_seeds: Signer<'a, 'a>) -> Self {
         self.signer_seeds = Some(signer_seeds);
+        self
+    }
+
+    pub fn maybe_validator(mut self, validator: Option<&'a AccountView>) -> Self {
+        self.validator = validator;
         self
     }
 

--- a/rust/sdk/src/access_control/instructions/delegate_permission.rs
+++ b/rust/sdk/src/access_control/instructions/delegate_permission.rs
@@ -30,7 +30,7 @@ pub struct DelegatePermission {
 
     pub delegation_program: Pubkey,
 
-    pub validator: Pubkey,
+    pub validator: Option<Pubkey>,
 }
 
 impl DelegatePermission {
@@ -43,7 +43,8 @@ impl DelegatePermission {
         &self,
         remaining_accounts: &[AccountMeta],
     ) -> Instruction {
-        let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
+        let optional_accounts = if self.validator.is_some() { 1 } else { 0 };
+        let mut accounts = Vec::with_capacity(10 + optional_accounts + remaining_accounts.len());
         accounts.push(AccountMeta::new(self.payer, true));
         accounts.push(AccountMeta::new_readonly(
             self.authority.0,
@@ -60,7 +61,9 @@ impl DelegatePermission {
         accounts.push(AccountMeta::new(self.delegation_record, false));
         accounts.push(AccountMeta::new(self.delegation_metadata, false));
         accounts.push(AccountMeta::new_readonly(self.delegation_program, false));
-        accounts.push(AccountMeta::new_readonly(self.validator, false));
+        if let Some(validator) = self.validator {
+            accounts.push(AccountMeta::new_readonly(validator, false));
+        }
         accounts.extend_from_slice(remaining_accounts);
         let data = DelegatePermissionInstructionData::new()
             .try_to_vec()
@@ -228,7 +231,7 @@ impl DelegatePermissionBuilder {
             delegation_program: self
                 .delegation_program
                 .expect("delegation_program is not set"),
-            validator: self.validator.expect("validator is not set"),
+            validator: self.validator,
         };
 
         accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
@@ -578,7 +581,7 @@ impl<'a, 'b> DelegatePermissionCpiBuilder<'a, 'b> {
                 .delegation_program
                 .expect("delegation_program is not set"),
 
-            validator: Some(self.instruction.validator.expect("validator is not set")),
+            validator: self.instruction.validator,
         };
         instruction.invoke_signed_with_remaining_accounts(
             signers_seeds,

--- a/rust/tests/access_control_test.rs
+++ b/rust/tests/access_control_test.rs
@@ -193,6 +193,43 @@ mod tests {
     }
 
     #[test]
+    fn test_delegate_permission_builder_with_validator() {
+        let payer = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let permissioned_account = Pubkey::new_unique();
+        let permission = Pubkey::new_unique();
+        let system_program = Pubkey::new_unique();
+        let owner_program = Pubkey::new_unique();
+        let delegation_buffer = Pubkey::new_unique();
+        let delegation_record = Pubkey::new_unique();
+        let delegation_metadata = Pubkey::new_unique();
+        let delegation_program = Pubkey::new_unique();
+        let validator = Pubkey::new_unique();
+
+        let mut builder = DelegatePermissionBuilder::new();
+        builder
+            .payer(payer)
+            .authority(authority, true)
+            .permissioned_account(permissioned_account, false)
+            .permission(permission)
+            .system_program(system_program)
+            .owner_program(owner_program)
+            .delegation_buffer(delegation_buffer)
+            .delegation_record(delegation_record)
+            .delegation_metadata(delegation_metadata)
+            .delegation_program(delegation_program)
+            .validator(Some(validator));
+
+        let instruction = builder.instruction();
+
+        assert_eq!(instruction.program_id, PERMISSION_PROGRAM_ID);
+        assert_eq!(instruction.accounts.len(), 11);
+        assert_eq!(instruction.accounts[0].pubkey, payer);
+        assert_eq!(instruction.accounts[9].pubkey, delegation_program);
+        assert_eq!(instruction.accounts[10].pubkey, validator);
+    }
+
+    #[test]
     fn test_update_permission_builder_both_signers() {
         let authority = Pubkey::new_unique();
         let permissioned_account = Pubkey::new_unique();

--- a/rust/tests/access_control_test.rs
+++ b/rust/tests/access_control_test.rs
@@ -5,7 +5,7 @@
 mod tests {
     use ephemeral_rollups_sdk::access_control::instructions::{
         ClosePermissionBuilder, CommitAndUndelegatePermissionBuilder, CommitPermissionBuilder,
-        CreatePermissionBuilder, UpdatePermissionBuilder,
+        CreatePermissionBuilder, DelegatePermissionBuilder, UpdatePermissionBuilder,
     };
     use ephemeral_rollups_sdk::access_control::structs::MembersArgs;
     use ephemeral_rollups_sdk::consts::PERMISSION_PROGRAM_ID;
@@ -155,6 +155,41 @@ mod tests {
         assert_eq!(instruction.accounts.len(), 4); // permissioned_account, permission, payer, system_program
         assert!(instruction.accounts[0].is_signer); // permissioned_account is signer
         assert!(instruction.accounts[2].is_signer); // payer is signer
+    }
+
+    #[test]
+    fn test_delegate_permission_builder_without_validator() {
+        let payer = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let permissioned_account = Pubkey::new_unique();
+        let permission = Pubkey::new_unique();
+        let system_program = Pubkey::new_unique();
+        let owner_program = Pubkey::new_unique();
+        let delegation_buffer = Pubkey::new_unique();
+        let delegation_record = Pubkey::new_unique();
+        let delegation_metadata = Pubkey::new_unique();
+        let delegation_program = Pubkey::new_unique();
+
+        let mut builder = DelegatePermissionBuilder::new();
+        builder
+            .payer(payer)
+            .authority(authority, true)
+            .permissioned_account(permissioned_account, false)
+            .permission(permission)
+            .system_program(system_program)
+            .owner_program(owner_program)
+            .delegation_buffer(delegation_buffer)
+            .delegation_record(delegation_record)
+            .delegation_metadata(delegation_metadata)
+            .delegation_program(delegation_program)
+            .validator(None);
+
+        let instruction = builder.instruction();
+
+        assert_eq!(instruction.program_id, PERMISSION_PROGRAM_ID);
+        assert_eq!(instruction.accounts.len(), 10);
+        assert_eq!(instruction.accounts[0].pubkey, payer);
+        assert_eq!(instruction.accounts[9].pubkey, delegation_program);
     }
 
     #[test]


### PR DESCRIPTION
The `delegate_permission` instruction has the validator account as optional but the `DelegatePermission` struct enforces to have passed the validator key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The validator parameter in permission delegation operations is now optional, providing greater flexibility in delegation workflows.

* **Tests**
  * Added test coverage for permission delegation without a specified validator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->