### PR TITLE
chore: adjust swap instructions args to be compatible with onchain ixdata

### DIFF
--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -1695,22 +1695,16 @@ describe("Exposed Instructions (web3.js)", () => {
       );
 
       const data = Buffer.from(instruction.data);
-      expect(data[0]).toBe(30); // discriminator
+      expect(data[0]).toBe(29); // discriminator
       expect(data.readUInt32LE(1)).toBe(7); // shuttle_id
       // Layout after the discriminator:
       //   [1..5) shuttle_id  [5] stash_bump  [6..38) mint
       //   [38..48) 10 bumps  → 3 vardata blobs start at 48.
       expect(data.subarray(6, 38).equals(mint.toBuffer())).toBe(true);
 
-      const [validatorField, nextOffset] = readLengthPrefixedField(data, 48);
-      const [destinationField, suffixOffset] = readLengthPrefixedField(
-        data,
-        nextOffset,
-      );
-      const [suffixField, endOffset] = readLengthPrefixedField(
-        data,
-        suffixOffset,
-      );
+      const validatorField = data.subarray(48, 80);
+      const destinationField = data.subarray(80, 160);
+      const [suffixField, endOffset] = readLengthPrefixedField(data, 160);
 
       expect(validatorField.equals(validator.toBuffer())).toBe(true);
       // ChaCha20-Poly1305 encryption: 32 (ephemeral pubkey) + plaintext +
@@ -1737,12 +1731,7 @@ describe("Exposed Instructions (web3.js)", () => {
       );
 
       const data = Buffer.from(instruction.data);
-      const [, afterValidator] = readLengthPrefixedField(data, 48);
-      const [, afterDestination] = readLengthPrefixedField(
-        data,
-        afterValidator,
-      );
-      const [suffixField] = readLengthPrefixedField(data, afterDestination);
+      const [suffixField] = readLengthPrefixedField(data, 160);
       // Suffix plaintext is now 28 bytes (+u64 clientRefId): 32 + 28 + 16 = 76.
       expect(suffixField).toHaveLength(76);
     });
@@ -1784,12 +1773,7 @@ describe("Exposed Instructions (web3.js)", () => {
       );
 
       const data = Buffer.from(instruction.data);
-      const [, afterValidator] = readLengthPrefixedField(data, 48);
-      const [, afterDestination] = readLengthPrefixedField(
-        data,
-        afterValidator,
-      );
-      const [suffixField] = readLengthPrefixedField(data, afterDestination);
+      const [suffixField] = readLengthPrefixedField(data, 160);
       expect(suffixField).toHaveLength(76);
     });
 

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/crypto.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/crypto.ts
@@ -3,7 +3,22 @@ import { blake2b } from "@noble/hashes/blake2b";
 import { edwardsToMontgomeryPub } from "@noble/curves/ed25519";
 import * as nacl from "tweetnacl";
 
-export function encryptEd25519Recipient(
+//
+// This constant defines the total overhead of sealed-box encryption,
+// and this value is the sum of the following two constants defined
+// by the library.
+//
+//  - nacl.box.publicKeyLength (32)
+//  - nacl.box.overheadLength (16)
+//
+// Do not confuse `publicKeyLength` with the second argument `recipient` of
+// the following encryptWithEd25519Recipient(). It is actually the pubkey
+// internally generated and added by the sealed-box encryption algorithn so
+// that recipient could send encrypted replies to the original sender.
+//
+export const ENCRYPTION_OVERHEAD = 48;
+
+export function encryptWithEd25519Recipient(
   plaintext: Uint8Array,
   recipient: PublicKey,
 ): Buffer {

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -27,7 +27,7 @@ import {
   processPendingTransferQueueRefillIx,
   toTransactionInstruction,
 } from "./transferQueue.js";
-import { encryptEd25519Recipient } from "./crypto.js";
+import { encryptWithEd25519Recipient, ENCRYPTION_OVERHEAD } from "./crypto.js";
 
 // Minimal SPL Token helpers (vendored) to avoid importing @solana/spl-token.
 // This prevents bundlers from pulling transitive deps like spl-token-group and
@@ -849,16 +849,16 @@ export function depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer
   const [vault] = deriveVault(mint);
   const vaultAta = deriveVaultAta(mint, vault);
   const [queue] = deriveTransferQueue(mint, validator);
-  const encryptedDestination = encryptEd25519Recipient(
+  const encryptedDestination = encryptWithEd25519Recipient(
     destinationOwner.toBytes(),
     validator,
   );
-  if (encryptedDestination.length !== 80) {
+  if (encryptedDestination.length !== 32 + ENCRYPTION_OVERHEAD) {
     throw new Error(
       `the length of encryptedDestination must be 80, not ${encryptedDestination.length}`,
     );
   }
-  const encryptedSuffix = encryptEd25519Recipient(
+  const encryptedSuffix = encryptWithEd25519Recipient(
     packPrivateTransferSuffix(minDelayMs, maxDelayMs, split, clientRefId),
     validator,
   );

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/schedulePrivateTransfer.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/schedulePrivateTransfer.ts
@@ -11,7 +11,7 @@ import {
   HYDRA_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
 } from "../../constants.js";
-import { encryptEd25519Recipient } from "./crypto.js";
+import { encryptWithEd25519Recipient, ENCRYPTION_OVERHEAD } from "./crypto.js";
 import {
   deriveRentPda,
   deriveShuttleAta,
@@ -24,7 +24,7 @@ import { deriveTransferQueue } from "./transferQueue.js";
 // Local constants (mirror the on-chain side)
 // ---------------------------------------------------------------------------
 
-const SCHEDULE_PRIVATE_TRANSFER_DISCRIMINATOR = 30;
+const SCHEDULE_PRIVATE_TRANSFER_DISCRIMINATOR = 29;
 
 const STASH_PDA_SEED = Buffer.from("stash");
 const HYDRA_CRANK_SEED_PREFIX = Buffer.from("crank");
@@ -112,7 +112,7 @@ function hydraSeed(stashPda: PublicKey, shuttleId: number): Buffer {
 // ---------------------------------------------------------------------------
 
 /**
- * Build a `schedule_private_transfer` instruction (discriminator 30).
+ * Build a `schedule_private_transfer` instruction (discriminator 29).
  *
  * Appends to a swap transaction so the swap's `destinationTokenAccount`
  * (which the caller sets to the stash ATA) gets privately forwarded to
@@ -221,11 +221,16 @@ export function schedulePrivateTransferIx(
   const [hydraCrankPda] = deriveHydraCrankPda(stashPda, shuttleId);
 
   // -------- build the encrypted payload (same shape as ix 25) --------
-  const encryptedDestination = encryptEd25519Recipient(
+  const encryptedDestination = encryptWithEd25519Recipient(
     destinationOwner.toBytes(),
     validator,
   );
-  const encryptedSuffix = encryptEd25519Recipient(
+  if (encryptedDestination.length !== 32 + ENCRYPTION_OVERHEAD) {
+    throw new Error(
+      `the length of encryptedDestination must be 80, not ${encryptedDestination.length}`,
+    );
+  }
+  const encryptedSuffix = encryptWithEd25519Recipient(
     packPrivateTransferSuffix(minDelayMs, maxDelayMs, split, clientRefId),
     validator,
   );
@@ -249,8 +254,8 @@ export function schedulePrivateTransferIx(
     Buffer.from([vaultTokenBump]),
     Buffer.from([stashAtaBump]),
     Buffer.from([queueBump]),
-    encodeLengthPrefixedBytes(validator.toBytes()),
-    encodeLengthPrefixedBytes(encryptedDestination),
+    validator.toBytes(),
+    encryptedDestination,
     encodeLengthPrefixedBytes(encryptedSuffix),
   ]);
 


### PR DESCRIPTION
Onchain related PR: https://github.com/magicblock-labs/ephemeral-spl-token/pull/75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified private transfer instruction protocol with updated encryption payload handling and data serialization
  * Enhanced encryption validation and payload processing logic for improved security and compatibility

* **Tests**
  * Updated test cases for private transfer instruction parsing and data field extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->