### PR TITLE
fix(kit): fetch initial resolver state without waiting for ws notification

### DIFF
--- a/ts/kit/src/__test__/resolver.test.ts
+++ b/ts/kit/src/__test__/resolver.test.ts
@@ -61,36 +61,66 @@ vi.mock("@solana/kit", () => ({
 
 function createNotificationStream() {
   const values: AccountNotification[] = [];
-  const waiters: Array<(result: IteratorResult<AccountNotification>) => void> =
-    [];
+  const waiters: Array<{
+    abortSignal?: AbortSignal;
+    onAbort?: () => void;
+    resolve: (result: IteratorResult<AccountNotification>) => void;
+  }> = [];
   let closed = false;
 
-  const stream: AsyncIterable<AccountNotification> = {
+  const resolveWaiter = (
+    waiter: (typeof waiters)[number],
+    result: IteratorResult<AccountNotification>,
+  ) => {
+    if (waiter.onAbort !== undefined) {
+      waiter.abortSignal?.removeEventListener("abort", waiter.onAbort);
+    }
+    waiter.resolve(result);
+  };
+
+  const stream = (
+    abortSignal?: AbortSignal,
+  ): AsyncIterable<AccountNotification> => ({
     [Symbol.asyncIterator]() {
       return {
         async next() {
-          if (closed) {
+          if (closed || abortSignal?.aborted === true) {
             return { done: true, value: undefined };
           }
 
-          const value = values.shift();
-          if (value !== undefined) {
-            return { done: false, value };
-          }
-
           return new Promise<IteratorResult<AccountNotification>>((resolve) => {
-            waiters.push(resolve);
+            const value = values.shift();
+            if (value !== undefined) {
+              resolve({ done: false, value });
+              return;
+            }
+
+            const waiter: (typeof waiters)[number] = {
+              abortSignal,
+              resolve,
+            };
+            waiter.onAbort = () => {
+              const index = waiters.indexOf(waiter);
+              if (index !== -1) {
+                waiters.splice(index, 1);
+              }
+              resolveWaiter(waiter, { done: true, value: undefined });
+            };
+            abortSignal?.addEventListener("abort", waiter.onAbort, {
+              once: true,
+            });
+            waiters.push(waiter);
           });
         },
       };
     },
-  };
+  });
 
   return {
     push(value: AccountNotification) {
       const waiter = waiters.shift();
       if (waiter !== undefined) {
-        waiter({ done: false, value });
+        resolveWaiter(waiter, { done: false, value });
         return;
       }
       values.push(value);
@@ -98,7 +128,7 @@ function createNotificationStream() {
     close() {
       closed = true;
       for (const waiter of waiters.splice(0)) {
-        waiter({ done: true, value: undefined });
+        resolveWaiter(waiter, { done: true, value: undefined });
       }
     },
     stream,
@@ -147,7 +177,9 @@ describe("Resolver", () => {
     getAccountInfoSend = vi.fn(async () => createAccountNotification(1n, null));
     getAccountInfo = vi.fn(() => ({ send: getAccountInfoSend }));
     accountNotifications = vi.fn(() => ({ subscribe }));
-    subscribe = vi.fn(async () => notificationStream.stream);
+    subscribe = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+      notificationStream.stream(abortSignal),
+    );
     chainRpc = { getAccountInfo };
 
     kitMocks.decodeDelegationRecord.mockReturnValue({
@@ -291,7 +323,7 @@ describe("Resolver", () => {
     });
   });
 
-  it("does not overwrite a fresher websocket notification with the initial fetch", async () => {
+  it("does not overwrite a same-slot websocket notification with the initial fetch", async () => {
     let resolveInitialFetch: ((value: AccountNotification) => void) | undefined;
     getAccountInfoSend.mockReturnValue(
       new Promise((resolve) => {
@@ -316,7 +348,7 @@ describe("Resolver", () => {
       expect(kitMocks.decodeDelegationRecord).toHaveBeenCalled();
     });
 
-    resolveInitialFetch?.(createAccountNotification(1n, null));
+    resolveInitialFetch?.(createAccountNotification(2n, null));
 
     await expect(trackAccount).resolves.toEqual({
       status: 0,

--- a/ts/kit/src/__test__/resolver.test.ts
+++ b/ts/kit/src/__test__/resolver.test.ts
@@ -7,8 +7,11 @@ import type {
 import { Resolver } from "../resolver";
 import { DELEGATION_PROGRAM_ID } from "../constants";
 
+type AccountInfo = (AccountInfoBase & AccountInfoWithBase64EncodedData) | null;
+
 interface AccountNotification {
-  value: (AccountInfoBase & AccountInfoWithBase64EncodedData) | null;
+  context: { slot: bigint };
+  value: AccountInfo;
 }
 
 const kitMocks = vi.hoisted(() => {
@@ -102,12 +105,25 @@ function createNotificationStream() {
   };
 }
 
-async function timeout(ms: number): Promise<"timeout"> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve("timeout");
-    }, ms);
-  });
+function createAccountNotification(
+  slot: bigint,
+  value: AccountInfo,
+): AccountNotification {
+  return {
+    context: { slot },
+    value,
+  };
+}
+
+function createDelegatedAccount(): AccountInfoBase &
+  AccountInfoWithBase64EncodedData {
+  return {
+    data: ["AAAA"],
+    executable: false,
+    lamports: 1n,
+    owner: DELEGATION_PROGRAM_ID,
+    space: 0n,
+  } as unknown as AccountInfoBase & AccountInfoWithBase64EncodedData;
 }
 
 describe("Resolver", () => {
@@ -122,12 +138,13 @@ describe("Resolver", () => {
   let accountNotifications: ReturnType<typeof vi.fn>;
   let subscribe: ReturnType<typeof vi.fn>;
   let chainRpc: { getAccountInfo: ReturnType<typeof vi.fn> };
+  let resolver: Resolver | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
     notificationStream = createNotificationStream();
-    getAccountInfoSend = vi.fn(async () => ({ value: null }));
+    getAccountInfoSend = vi.fn(async () => createAccountNotification(1n, null));
     getAccountInfo = vi.fn(() => ({ send: getAccountInfoSend }));
     accountNotifications = vi.fn(() => ({ subscribe }));
     subscribe = vi.fn(async () => notificationStream.stream);
@@ -148,19 +165,19 @@ describe("Resolver", () => {
   });
 
   afterEach(() => {
+    resolver?.terminate();
     notificationStream.close();
+    resolver = undefined;
   });
 
   it("returns from initial fetch without waiting for a websocket notification", async () => {
-    const resolver = new Resolver(
+    const currentResolver = new Resolver(
       { chain: chainUrl, websocket: "wss://base.example" },
       new Map(),
     );
+    resolver = currentResolver;
 
-    const result = await Promise.race([
-      resolver.trackAccount(accountAddress),
-      timeout(50),
-    ]);
+    const result = await currentResolver.trackAccount(accountAddress);
 
     expect(result).toEqual({ status: 1 });
     expect(accountNotifications).toHaveBeenCalledWith(
@@ -183,48 +200,101 @@ describe("Resolver", () => {
   });
 
   it("does not hang when no websocket notification arrives immediately", async () => {
-    let resolveInitialFetch: ((value: { value: null }) => void) | undefined;
+    let resolveInitialFetch: ((value: AccountNotification) => void) | undefined;
     getAccountInfoSend.mockReturnValue(
       new Promise((resolve) => {
         resolveInitialFetch = resolve;
       }),
     );
-    const resolver = new Resolver(
+    const currentResolver = new Resolver(
       { chain: chainUrl, websocket: "wss://base.example" },
       new Map(),
     );
+    resolver = currentResolver;
 
-    const trackAccount = resolver.trackAccount(accountAddress);
+    const trackAccount = currentResolver.trackAccount(accountAddress);
     await vi.waitFor(() => {
       expect(getAccountInfo).toHaveBeenCalled();
     });
 
-    resolveInitialFetch?.({ value: null });
+    resolveInitialFetch?.(createAccountNotification(1n, null));
     await expect(trackAccount).resolves.toEqual({ status: 1 });
   });
 
   it("continues tracking account updates after returning initial state", async () => {
-    const resolver = new Resolver(
+    const currentResolver = new Resolver(
       { chain: chainUrl, websocket: "wss://base.example" },
       new Map([[kitMocks.validatorAddress, routeUrl]]),
     );
+    resolver = currentResolver;
 
-    await expect(resolver.trackAccount(accountAddress)).resolves.toEqual({
-      status: 1,
-    });
+    await expect(currentResolver.trackAccount(accountAddress)).resolves.toEqual(
+      {
+        status: 1,
+      },
+    );
 
-    notificationStream.push({
-      value: {
-        data: ["AAAA"],
-        executable: false,
-        lamports: 1n,
-        owner: DELEGATION_PROGRAM_ID,
-        space: 0n,
-      } as unknown as AccountInfoBase & AccountInfoWithBase64EncodedData,
-    });
+    notificationStream.push(
+      createAccountNotification(2n, createDelegatedAccount()),
+    );
 
     await vi.waitFor(async () => {
-      await expect(resolver.resolve(accountAddress)).resolves.toBe(routeRpc);
+      await expect(currentResolver.resolve(accountAddress)).resolves.toBe(
+        routeRpc,
+      );
     });
+  });
+
+  it("does not overwrite a fresher websocket notification with the initial fetch", async () => {
+    let resolveInitialFetch: ((value: AccountNotification) => void) | undefined;
+    getAccountInfoSend.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInitialFetch = resolve;
+      }),
+    );
+    const currentResolver = new Resolver(
+      { chain: chainUrl, websocket: "wss://base.example" },
+      new Map([[kitMocks.validatorAddress, routeUrl]]),
+    );
+    resolver = currentResolver;
+
+    const trackAccount = currentResolver.trackAccount(accountAddress);
+    await vi.waitFor(() => {
+      expect(getAccountInfo).toHaveBeenCalled();
+    });
+
+    notificationStream.push(
+      createAccountNotification(2n, createDelegatedAccount()),
+    );
+    await vi.waitFor(() => {
+      expect(kitMocks.decodeDelegationRecord).toHaveBeenCalled();
+    });
+
+    resolveInitialFetch?.(createAccountNotification(1n, null));
+
+    await expect(trackAccount).resolves.toEqual({
+      status: 0,
+      validator: kitMocks.validatorAddress,
+    });
+    await expect(currentResolver.resolve(accountAddress)).resolves.toBe(
+      routeRpc,
+    );
+  });
+
+  it("terminates active account subscriptions", async () => {
+    const currentResolver = new Resolver(
+      { chain: chainUrl, websocket: "wss://base.example" },
+      new Map(),
+    );
+    resolver = currentResolver;
+
+    await currentResolver.trackAccount(accountAddress);
+    const abortSignal = subscribe.mock.calls[0][0].abortSignal as AbortSignal;
+
+    expect(abortSignal.aborted).toBe(false);
+
+    currentResolver.terminate();
+
+    expect(abortSignal.aborted).toBe(true);
   });
 });

--- a/ts/kit/src/__test__/resolver.test.ts
+++ b/ts/kit/src/__test__/resolver.test.ts
@@ -221,6 +221,35 @@ describe("Resolver", () => {
     await expect(trackAccount).resolves.toEqual({ status: 1 });
   });
 
+  it("deduplicates concurrent tracking for the same account", async () => {
+    let resolveInitialFetch: ((value: AccountNotification) => void) | undefined;
+    getAccountInfoSend.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInitialFetch = resolve;
+      }),
+    );
+    const currentResolver = new Resolver(
+      { chain: chainUrl, websocket: "wss://base.example" },
+      new Map(),
+    );
+    resolver = currentResolver;
+
+    const firstTrack = currentResolver.trackAccount(accountAddress);
+    const secondTrack = currentResolver.trackAccount(accountAddress);
+    await vi.waitFor(() => {
+      expect(getAccountInfo).toHaveBeenCalled();
+    });
+
+    expect(accountNotifications).toHaveBeenCalledTimes(1);
+    expect(subscribe).toHaveBeenCalledTimes(1);
+
+    resolveInitialFetch?.(createAccountNotification(1n, null));
+    await expect(Promise.all([firstTrack, secondTrack])).resolves.toEqual([
+      { status: 1 },
+      { status: 1 },
+    ]);
+  });
+
   it("aborts the subscription when the initial fetch fails", async () => {
     const fetchError = new Error("initial fetch failed");
     getAccountInfoSend.mockRejectedValue(fetchError);

--- a/ts/kit/src/__test__/resolver.test.ts
+++ b/ts/kit/src/__test__/resolver.test.ts
@@ -221,6 +221,23 @@ describe("Resolver", () => {
     await expect(trackAccount).resolves.toEqual({ status: 1 });
   });
 
+  it("aborts the subscription when the initial fetch fails", async () => {
+    const fetchError = new Error("initial fetch failed");
+    getAccountInfoSend.mockRejectedValue(fetchError);
+    const currentResolver = new Resolver(
+      { chain: chainUrl, websocket: "wss://base.example" },
+      new Map(),
+    );
+    resolver = currentResolver;
+
+    await expect(currentResolver.trackAccount(accountAddress)).rejects.toThrow(
+      fetchError,
+    );
+
+    const abortSignal = subscribe.mock.calls[0][0].abortSignal as AbortSignal;
+    expect(abortSignal.aborted).toBe(true);
+  });
+
   it("continues tracking account updates after returning initial state", async () => {
     const currentResolver = new Resolver(
       { chain: chainUrl, websocket: "wss://base.example" },

--- a/ts/kit/src/__test__/resolver.test.ts
+++ b/ts/kit/src/__test__/resolver.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AccountInfoBase,
+  AccountInfoWithBase64EncodedData,
+  Address,
+} from "@solana/kit";
+import { Resolver } from "../resolver";
+import { DELEGATION_PROGRAM_ID } from "../constants";
+
+interface AccountNotification {
+  value: (AccountInfoBase & AccountInfoWithBase64EncodedData) | null;
+}
+
+const kitMocks = vi.hoisted(() => {
+  const delegationRecordAddress =
+    "DelegationRecord111111111111111111111111111" as Address;
+  const validatorAddress =
+    "Validator1111111111111111111111111111111" as Address;
+  const decodeDelegationRecord = vi.fn(() => ({ validator: validatorAddress }));
+
+  return {
+    address: vi.fn((value: string) => value as Address),
+    createSolanaRpc: vi.fn(),
+    createSolanaRpcSubscriptions: vi.fn(),
+    decodeDelegationRecord,
+    delegationRecordAddress,
+    getAddressCodec: vi.fn(() => ({})),
+    getAddressEncoder: vi.fn(() => ({
+      encode: vi.fn(() => new Uint8Array([1])),
+    })),
+    getProgramDerivedAddress: vi.fn(async () => [delegationRecordAddress]),
+    getStructCodec: vi.fn(() => ({
+      decode: vi.fn(() => decodeDelegationRecord()),
+    })),
+    getU8Codec: vi.fn(() => ({})),
+    lamports: vi.fn((value: bigint) => value),
+    validatorAddress,
+  };
+});
+
+vi.mock("@solana/kit", () => ({
+  AccountRole: {
+    READONLY: 0,
+    READONLY_SIGNER: 1,
+    WRITABLE: 2,
+    WRITABLE_SIGNER: 3,
+  },
+  address: kitMocks.address,
+  createSolanaRpc: kitMocks.createSolanaRpc,
+  createSolanaRpcSubscriptions: kitMocks.createSolanaRpcSubscriptions,
+  getAddressCodec: kitMocks.getAddressCodec,
+  getAddressEncoder: kitMocks.getAddressEncoder,
+  getProgramDerivedAddress: kitMocks.getProgramDerivedAddress,
+  getStructCodec: kitMocks.getStructCodec,
+  getU8Codec: kitMocks.getU8Codec,
+  lamports: kitMocks.lamports,
+}));
+
+function createNotificationStream() {
+  const values: AccountNotification[] = [];
+  const waiters: Array<(result: IteratorResult<AccountNotification>) => void> =
+    [];
+  let closed = false;
+
+  const stream: AsyncIterable<AccountNotification> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          if (closed) {
+            return { done: true, value: undefined };
+          }
+
+          const value = values.shift();
+          if (value !== undefined) {
+            return { done: false, value };
+          }
+
+          return new Promise<IteratorResult<AccountNotification>>((resolve) => {
+            waiters.push(resolve);
+          });
+        },
+      };
+    },
+  };
+
+  return {
+    push(value: AccountNotification) {
+      const waiter = waiters.shift();
+      if (waiter !== undefined) {
+        waiter({ done: false, value });
+        return;
+      }
+      values.push(value);
+    },
+    close() {
+      closed = true;
+      for (const waiter of waiters.splice(0)) {
+        waiter({ done: true, value: undefined });
+      }
+    },
+    stream,
+  };
+}
+
+async function timeout(ms: number): Promise<"timeout"> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve("timeout");
+    }, ms);
+  });
+}
+
+describe("Resolver", () => {
+  const accountAddress = "Account11111111111111111111111111111111" as Address;
+  const chainUrl = "https://base.example";
+  const routeUrl = "https://er.example";
+  const routeRpc = { endpoint: routeUrl };
+
+  let notificationStream: ReturnType<typeof createNotificationStream>;
+  let getAccountInfo: ReturnType<typeof vi.fn>;
+  let getAccountInfoSend: ReturnType<typeof vi.fn>;
+  let accountNotifications: ReturnType<typeof vi.fn>;
+  let subscribe: ReturnType<typeof vi.fn>;
+  let chainRpc: { getAccountInfo: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    notificationStream = createNotificationStream();
+    getAccountInfoSend = vi.fn(async () => ({ value: null }));
+    getAccountInfo = vi.fn(() => ({ send: getAccountInfoSend }));
+    accountNotifications = vi.fn(() => ({ subscribe }));
+    subscribe = vi.fn(async () => notificationStream.stream);
+    chainRpc = { getAccountInfo };
+
+    kitMocks.decodeDelegationRecord.mockReturnValue({
+      validator: kitMocks.validatorAddress,
+    });
+    kitMocks.createSolanaRpc.mockImplementation((url: string) => {
+      if (url === routeUrl) {
+        return routeRpc;
+      }
+      return chainRpc;
+    });
+    kitMocks.createSolanaRpcSubscriptions.mockReturnValue({
+      accountNotifications,
+    });
+  });
+
+  afterEach(() => {
+    notificationStream.close();
+  });
+
+  it("returns from initial fetch without waiting for a websocket notification", async () => {
+    const resolver = new Resolver(
+      { chain: chainUrl, websocket: "wss://base.example" },
+      new Map(),
+    );
+
+    const result = await Promise.race([
+      resolver.trackAccount(accountAddress),
+      timeout(50),
+    ]);
+
+    expect(result).toEqual({ status: 1 });
+    expect(accountNotifications).toHaveBeenCalledWith(
+      kitMocks.delegationRecordAddress,
+      {
+        commitment: "confirmed",
+        encoding: "base64",
+      },
+    );
+    expect(subscribe).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
+    });
+    expect(getAccountInfo).toHaveBeenCalledWith(
+      kitMocks.delegationRecordAddress,
+      {
+        commitment: "confirmed",
+        encoding: "base64",
+      },
+    );
+  });
+
+  it("does not hang when no websocket notification arrives immediately", async () => {
+    let resolveInitialFetch: ((value: { value: null }) => void) | undefined;
+    getAccountInfoSend.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInitialFetch = resolve;
+      }),
+    );
+    const resolver = new Resolver(
+      { chain: chainUrl, websocket: "wss://base.example" },
+      new Map(),
+    );
+
+    const trackAccount = resolver.trackAccount(accountAddress);
+    await vi.waitFor(() => {
+      expect(getAccountInfo).toHaveBeenCalled();
+    });
+
+    resolveInitialFetch?.({ value: null });
+    await expect(trackAccount).resolves.toEqual({ status: 1 });
+  });
+
+  it("continues tracking account updates after returning initial state", async () => {
+    const resolver = new Resolver(
+      { chain: chainUrl, websocket: "wss://base.example" },
+      new Map([[kitMocks.validatorAddress, routeUrl]]),
+    );
+
+    await expect(resolver.trackAccount(accountAddress)).resolves.toEqual({
+      status: 1,
+    });
+
+    notificationStream.push({
+      value: {
+        data: ["AAAA"],
+        executable: false,
+        lamports: 1n,
+        owner: DELEGATION_PROGRAM_ID,
+        space: 0n,
+      } as unknown as AccountInfoBase & AccountInfoWithBase64EncodedData,
+    });
+
+    await vi.waitFor(async () => {
+      await expect(resolver.resolve(accountAddress)).resolves.toBe(routeRpc);
+    });
+  });
+});

--- a/ts/kit/src/resolver.ts
+++ b/ts/kit/src/resolver.ts
@@ -45,12 +45,14 @@ type DelegationRecord =
 
 type AccountInfo = (AccountInfoBase & AccountInfoWithBase64EncodedData) | null;
 type AccountNotification = SolanaRpcResponse<AccountInfo>;
+type AccountInfoSource = "initial" | "notification";
 
 /** Class responsible for resolving connections to Solana validators */
 export class Resolver {
   private readonly routes = new Map<string, Rpc<SolanaRpcApiDevnet>>();
   private readonly delegations = new Map<string, DelegationRecord>();
   private readonly delegationSlots = new Map<string, Slot>();
+  private readonly delegationSources = new Map<string, AccountInfoSource>();
   private readonly inFlightTracks = new Map<
     string,
     Promise<DelegationRecord>
@@ -131,7 +133,7 @@ export class Resolver {
         })
         .send();
 
-      return this.updateStatusFromResponse(accountInfo, pubkey);
+      return this.updateStatusFromResponse(accountInfo, pubkey, "initial");
     } catch (error) {
       abortController.abort();
       this.subs.delete(pubkeyStr);
@@ -204,7 +206,11 @@ export class Resolver {
       let shouldClearStatus = false;
       try {
         for await (const accountNotification of accountNotifications) {
-          this.updateStatusFromResponse(accountNotification, pubkey);
+          this.updateStatusFromResponse(
+            accountNotification,
+            pubkey,
+            "notification",
+          );
         }
         shouldClearStatus = !abortController.signal.aborted;
       } catch (error: unknown) {
@@ -223,6 +229,7 @@ export class Resolver {
         if (shouldClearStatus) {
           this.delegations.delete(pubkeyStr);
           this.delegationSlots.delete(pubkeyStr);
+          this.delegationSources.delete(pubkeyStr);
         }
       }
     })();
@@ -231,19 +238,25 @@ export class Resolver {
   private updateStatusFromResponse(
     accountNotification: AccountNotification,
     pubkey: Address,
+    source: AccountInfoSource,
   ): DelegationRecord {
     const pubkeyStr = pubkey.toString();
     const currentSlot = this.delegationSlots.get(pubkeyStr);
+    const currentSource = this.delegationSources.get(pubkeyStr);
     const currentRecord = this.delegations.get(pubkeyStr);
     if (
       currentSlot !== undefined &&
-      accountNotification.context.slot < currentSlot &&
+      (accountNotification.context.slot < currentSlot ||
+        (accountNotification.context.slot === currentSlot &&
+          currentSource === "notification" &&
+          source === "initial")) &&
       currentRecord !== undefined
     ) {
       return currentRecord;
     }
 
     this.delegationSlots.set(pubkeyStr, accountNotification.context.slot);
+    this.delegationSources.set(pubkeyStr, source);
     return this.updateStatus(accountNotification.value, pubkey);
   }
 

--- a/ts/kit/src/resolver.ts
+++ b/ts/kit/src/resolver.ts
@@ -100,14 +100,20 @@ export class Resolver {
       abortController,
     );
 
-    const accountInfo = await this.chain
-      .getAccountInfo(delegationRecord, {
-        commitment: "confirmed",
-        encoding: "base64",
-      })
-      .send();
+    try {
+      const accountInfo = await this.chain
+        .getAccountInfo(delegationRecord, {
+          commitment: "confirmed",
+          encoding: "base64",
+        })
+        .send();
 
-    return this.updateStatusFromResponse(accountInfo, pubkey);
+      return this.updateStatusFromResponse(accountInfo, pubkey);
+    } catch (error) {
+      abortController.abort();
+      this.subs.delete(pubkeyStr);
+      throw error;
+    }
   }
 
   /**

--- a/ts/kit/src/resolver.ts
+++ b/ts/kit/src/resolver.ts
@@ -41,6 +41,10 @@ type DelegationRecord =
   | { status: DelegationStatus.Delegated; validator: Address }
   | { status: DelegationStatus.Undelegated };
 
+interface AccountNotification {
+  value: (AccountInfoBase & AccountInfoWithBase64EncodedData) | null;
+}
+
 /** Class responsible for resolving connections to Solana validators */
 export class Resolver {
   private readonly routes = new Map<string, Rpc<SolanaRpcApiDevnet>>();
@@ -86,11 +90,7 @@ export class Resolver {
         encoding: "base64",
       })
       .subscribe({ abortSignal: abortController.signal });
-
-    for await (const accountNotification of accountNotifications) {
-      this.updateStatus(accountNotification.value, pubkey);
-      abortController.abort();
-    }
+    this.listenForAccountNotifications(accountNotifications, pubkey);
 
     const accountInfo = await this.chain
       .getAccountInfo(delegationRecord, {
@@ -144,6 +144,22 @@ export class Resolver {
       : validators.size === 0
         ? this.chain
         : undefined;
+  }
+
+  private listenForAccountNotifications(
+    accountNotifications: AsyncIterable<AccountNotification>,
+    pubkey: Address,
+  ) {
+    void (async () => {
+      for await (const accountNotification of accountNotifications) {
+        this.updateStatus(accountNotification.value, pubkey);
+      }
+    })().catch((error: unknown) => {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+      console.error(`Account subscription failed for ${pubkey}:`, error);
+    });
   }
 
   private updateStatus(

--- a/ts/kit/src/resolver.ts
+++ b/ts/kit/src/resolver.ts
@@ -51,6 +51,11 @@ export class Resolver {
   private readonly routes = new Map<string, Rpc<SolanaRpcApiDevnet>>();
   private readonly delegations = new Map<string, DelegationRecord>();
   private readonly delegationSlots = new Map<string, Slot>();
+  private readonly inFlightTracks = new Map<
+    string,
+    Promise<DelegationRecord>
+  >();
+
   private readonly chain: Rpc<SolanaRpcApiDevnet>;
   private readonly ws: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
   private readonly subs = new Map<string, AbortController>();
@@ -80,6 +85,24 @@ export class Resolver {
       );
     }
 
+    const inFlightTrack = this.inFlightTracks.get(pubkeyStr);
+    if (inFlightTrack !== undefined) {
+      return inFlightTrack;
+    }
+
+    const track = this.startTrackingAccount(pubkey, pubkeyStr);
+    this.inFlightTracks.set(pubkeyStr, track);
+    try {
+      return await track;
+    } finally {
+      this.inFlightTracks.delete(pubkeyStr);
+    }
+  }
+
+  private async startTrackingAccount(
+    pubkey: Address,
+    pubkeyStr: string,
+  ): Promise<DelegationRecord> {
     const addressEncoder = getAddressEncoder();
     const [delegationRecord] = await getProgramDerivedAddress({
       programAddress: DELEGATION_PROGRAM_ID,

--- a/ts/kit/src/resolver.ts
+++ b/ts/kit/src/resolver.ts
@@ -17,6 +17,8 @@ import {
   getAddressCodec,
   getU8Codec,
   AccountRole,
+  type Slot,
+  type SolanaRpcResponse,
 } from "@solana/kit";
 import { DELEGATION_PROGRAM_ID } from "./constants.js";
 
@@ -41,16 +43,17 @@ type DelegationRecord =
   | { status: DelegationStatus.Delegated; validator: Address }
   | { status: DelegationStatus.Undelegated };
 
-interface AccountNotification {
-  value: (AccountInfoBase & AccountInfoWithBase64EncodedData) | null;
-}
+type AccountInfo = (AccountInfoBase & AccountInfoWithBase64EncodedData) | null;
+type AccountNotification = SolanaRpcResponse<AccountInfo>;
 
 /** Class responsible for resolving connections to Solana validators */
 export class Resolver {
   private readonly routes = new Map<string, Rpc<SolanaRpcApiDevnet>>();
   private readonly delegations = new Map<string, DelegationRecord>();
+  private readonly delegationSlots = new Map<string, Slot>();
   private readonly chain: Rpc<SolanaRpcApiDevnet>;
   private readonly ws: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+  private readonly subs = new Map<string, AbortController>();
 
   constructor(config: Configuration, routes: Map<string, string>) {
     this.chain = createSolanaRpc(config.chain);
@@ -90,7 +93,12 @@ export class Resolver {
         encoding: "base64",
       })
       .subscribe({ abortSignal: abortController.signal });
-    this.listenForAccountNotifications(accountNotifications, pubkey);
+    this.subs.set(pubkeyStr, abortController);
+    this.listenForAccountNotifications(
+      accountNotifications,
+      pubkey,
+      abortController,
+    );
 
     const accountInfo = await this.chain
       .getAccountInfo(delegationRecord, {
@@ -99,7 +107,7 @@ export class Resolver {
       })
       .send();
 
-    return this.updateStatus(accountInfo.value, pubkey);
+    return this.updateStatusFromResponse(accountInfo, pubkey);
   }
 
   /**
@@ -146,24 +154,72 @@ export class Resolver {
         : undefined;
   }
 
+  /**
+   * Terminates all active WebSocket subscriptions.
+   * Should be called to clean up resources when the resolver is no longer needed.
+   */
+  public terminate(): void {
+    for (const sub of this.subs.values()) {
+      sub.abort();
+    }
+    this.subs.clear();
+  }
+
   private listenForAccountNotifications(
     accountNotifications: AsyncIterable<AccountNotification>,
     pubkey: Address,
+    abortController: AbortController,
   ) {
+    const pubkeyStr = pubkey.toString();
     void (async () => {
-      for await (const accountNotification of accountNotifications) {
-        this.updateStatus(accountNotification.value, pubkey);
+      let shouldClearStatus = false;
+      try {
+        for await (const accountNotification of accountNotifications) {
+          this.updateStatusFromResponse(accountNotification, pubkey);
+        }
+        shouldClearStatus = !abortController.signal.aborted;
+      } catch (error: unknown) {
+        if (
+          (error instanceof DOMException || error instanceof Error) &&
+          error.name === "AbortError"
+        ) {
+          return;
+        }
+        shouldClearStatus = true;
+        console.error(`Account subscription failed for ${pubkey}:`, error);
+      } finally {
+        if (this.subs.get(pubkeyStr) === abortController) {
+          this.subs.delete(pubkeyStr);
+        }
+        if (shouldClearStatus) {
+          this.delegations.delete(pubkeyStr);
+          this.delegationSlots.delete(pubkeyStr);
+        }
       }
-    })().catch((error: unknown) => {
-      if (error instanceof DOMException && error.name === "AbortError") {
-        return;
-      }
-      console.error(`Account subscription failed for ${pubkey}:`, error);
-    });
+    })();
+  }
+
+  private updateStatusFromResponse(
+    accountNotification: AccountNotification,
+    pubkey: Address,
+  ): DelegationRecord {
+    const pubkeyStr = pubkey.toString();
+    const currentSlot = this.delegationSlots.get(pubkeyStr);
+    const currentRecord = this.delegations.get(pubkeyStr);
+    if (
+      currentSlot !== undefined &&
+      accountNotification.context.slot < currentSlot &&
+      currentRecord !== undefined
+    ) {
+      return currentRecord;
+    }
+
+    this.delegationSlots.set(pubkeyStr, accountNotification.context.slot);
+    return this.updateStatus(accountNotification.value, pubkey);
   }
 
   private updateStatus(
-    account: (AccountInfoBase & AccountInfoWithBase64EncodedData) | null,
+    account: AccountInfo,
     pubkey: Address,
   ): DelegationRecord {
     const isDelegated =


### PR DESCRIPTION
## Issue

`Resolver.trackAccount()` subscribes to account websocket updates before fetching the current delegation account state, but the current implementation waits for the first websocket notification before calling `getAccountInfo`.

If no notification arrives immediately, `trackAccount()` can hang or delay returning the initial delegation status. The notification loop also aborts after the first update, which makes tracking effectively one-shot.

## Changes

- Start listening for account websocket notifications in the background.
- Fetch the initial account state immediately after subscription setup.
- Keep applying later websocket updates to the cached delegation status.
- Add focused resolver tests for the initial-fetch path and continued update handling.

## Tests

- `npm test -- src/__test__/resolver.test.ts`
- `npx eslint -c .eslintrc.yml src/resolver.ts src/__test__/resolver.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic tests for account routing/resolution and notification handling, including a controllable async notification stream and per-test lifecycle cleanup.

* **Bug Fixes**
  * Prevented stale notifications from overwriting newer state; ensured failed initial fetches abort subscriptions and avoid hangs/leaks.
  * Deduplicated concurrent tracking requests for the same account.

* **New Features**
  * Added a termination capability to abort active account subscriptions and clear background listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->