### PR TITLE
release sdk v0.14.2 (v0.14.1 -> v0.14.2)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-pinocchio"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bincode 1.3.3",
  "bincode 2.0.1",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anchor-lang 0.32.1",
  "anchor-lang 1.0.2",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-action"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral-accounts"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "magic-resolver"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "base64 0.12.3",
  "bincode 1.3.3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 edition = "2021"
 license = "MIT"
@@ -24,12 +24,12 @@ readme = "README.md"
 keywords = ["solana", "crypto", "delegation", "ephemeral-rollups", "magicblock"]
 
 [workspace.dependencies]
-ephemeral-rollups-sdk = { path = "sdk", version = "=0.14.1" }
-ephemeral-rollups-sdk-attribute-ephemeral = { path = "ephemeral", version = "=0.14.1" }
-ephemeral-rollups-sdk-attribute-ephemeral-accounts = { path = "ephemeral-accounts-attribute", version = "=0.14.1" }
-ephemeral-rollups-sdk-attribute-delegate = { path = "delegate", version = "=0.14.1" }
-ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = "=0.14.1" }
-ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = "=0.14.1" }
+ephemeral-rollups-sdk = { path = "sdk", version = "=0.14.2" }
+ephemeral-rollups-sdk-attribute-ephemeral = { path = "ephemeral", version = "=0.14.2" }
+ephemeral-rollups-sdk-attribute-ephemeral-accounts = { path = "ephemeral-accounts-attribute", version = "=0.14.2" }
+ephemeral-rollups-sdk-attribute-delegate = { path = "delegate", version = "=0.14.2" }
+ephemeral-rollups-sdk-attribute-commit = { path = "commit-attribute", version = "=0.14.2" }
+ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = "=0.14.2" }
 
 # Magicblock
 magicblock-delegation-program-api = { version = "3.0.0", default-features = false }

--- a/ts/kit/package.json
+++ b/ts/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-rollups-kit",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": "MagicBlock Labs",
   "license": "MIT",
   "publishConfig": {

--- a/ts/web3js/package.json
+++ b/ts/web3js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-rollups-sdk",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": "MagicBlock Labs",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.14.2 across Rust and TypeScript packages, including workspace crates and SDK dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/ephemeral-rollups-sdk/pull/220)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->