### PR TITLE
fix: PDA as a signer

### DIFF
--- a/rust/sdk/src/ephem/mod.rs
+++ b/rust/sdk/src/ephem/mod.rs
@@ -224,8 +224,8 @@ impl<'info> MagicIntentBundleBuilder<'info> {
         let add_callback_ixs = self.build_callback_ixs();
 
         // Build ScheduleIntentBundle instruction
-        let mut all_accounts = vec![self.payer, self.magic_context];
-        if let Some(vault) = self.magic_fee_vault {
+        let mut all_accounts = vec![self.payer.clone(), self.magic_context.clone()];
+        if let Some(vault) = self.magic_fee_vault.clone() {
             all_accounts.push(vault);
         }
         self.intent_bundle.collect_accounts(&mut all_accounts);
@@ -233,10 +233,28 @@ impl<'info> MagicIntentBundleBuilder<'info> {
         let args = self.intent_bundle.into_args(&indices_map);
         let metas = all_accounts
             .iter()
-            .map(|ai| AccountMeta {
-                pubkey: *ai.key.as_modern(),
-                is_signer: ai.is_signer,
-                is_writable: ai.is_writable,
+            .map(|ai| {
+                let mut meta = AccountMeta {
+                    pubkey: *ai.key.as_modern(),
+                    is_signer: ai.is_signer,
+                    is_writable: ai.is_writable,
+                };
+
+                // Set correct meta for fixed accounts
+                if ai.key == self.payer.key {
+                    meta.is_signer = true;
+                    meta.is_writable = true;
+                }
+                if ai.key == self.magic_context.key {
+                    meta.is_writable = true;
+                    meta.is_signer = false;
+                }
+                if Some(ai.key) == self.magic_fee_vault.as_ref().map(|el| el.key) {
+                    meta.is_writable = true;
+                    meta.is_signer = false;
+                }
+
+                meta
             })
             .collect();
         let schedule_ix = Instruction::new_with_bincode(


### PR DESCRIPTION
Enable PDA to be signer. prior meta was derived from account info for payer. If payer was PDA it would likely have `is_signer=false`. This pr forces a proper metas for fixed sets of accounts: `payer`, `magic_context`, `magic_fee_vault`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account metadata flag handling to ensure critical transaction accounts are correctly marked with appropriate signer and writable status during transaction construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/ephemeral-rollups-sdk/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->