### PR TITLE
fix: packed address tree info byte order

### DIFF
--- a/rust/pinocchio/Cargo.toml
+++ b/rust/pinocchio/Cargo.toml
@@ -24,7 +24,6 @@ pinocchio-log = { workspace = true }
 solana-address = { version = ">=2, <3", default-features = false, features = [
     "curve25519",
 ] }
-solana-program = { workspace = true, default-features = false }
 
 [dev-dependencies]
 bincode1 = { package = "bincode", version = "1.3" }

--- a/ts/web3js/src/compression/index.ts
+++ b/ts/web3js/src/compression/index.ts
@@ -79,18 +79,21 @@ export function convertValidityProofToBytes(
 export function convertPackedAddressTreeInfoToBytes(
   packedAddressTreeInfo: PackedAddressTreeInfo,
 ) {
+  // Wire layout must match the on-chain `CdpPackedAddressTreeInfo` decoder in
+  // magicblock-validator's compressed-delegation-api:
+  //   byte 0:    address_merkle_tree_pubkey_index (u8)
+  //   byte 1:    address_queue_pubkey_index      (u8)
+  //   bytes 2-3: root_index                      (u16 LE)
   const packedAddressTreeInfoBytes = Buffer.alloc(4);
-  // rootIndex is two bytes, little-endian
-  packedAddressTreeInfoBytes.writeUInt16LE(packedAddressTreeInfo.rootIndex, 0);
   packedAddressTreeInfoBytes.writeUInt8(
     packedAddressTreeInfo.addressMerkleTreePubkeyIndex,
-    2,
+    0,
   );
-  packedAddressTreeInfo.addressMerkleTreePubkeyIndex;
   packedAddressTreeInfoBytes.writeUInt8(
     packedAddressTreeInfo.addressQueuePubkeyIndex,
-    3,
+    1,
   );
+  packedAddressTreeInfoBytes.writeUInt16LE(packedAddressTreeInfo.rootIndex, 2);
   return packedAddressTreeInfoBytes;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to use a newer version of a core library with specific feature flags enabled.

* **Bug Fixes**
  * Improved data serialization handling to ensure correct byte layout ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/ephemeral-rollups-sdk/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->