### PR TITLE
Add delegation record resolver helpers

### DIFF
--- a/ts/kit/src/__test__/resolver.test.ts
+++ b/ts/kit/src/__test__/resolver.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AccountInfoBase,
+  AccountInfoWithBase64EncodedData,
+  Address,
+  getAddressEncoder,
+  lamports,
+  Rpc,
+  SolanaRpcApiDevnet,
+} from "@solana/kit";
+import { SYSTEM_PROGRAM_ADDRESS } from "@solana-program/system";
+
+import { DELEGATION_PROGRAM_ID } from "../constants.js";
+import { delegationRecordPdaFromDelegatedAccount } from "../pda.js";
+import {
+  DelegationStatus,
+  getDelegationRecord,
+  parseDelegationRecordAccount,
+} from "../resolver.js";
+
+type DelegationAccountInfo = AccountInfoBase & AccountInfoWithBase64EncodedData;
+
+const delegatedAccount =
+  "11111111111111111111111111111111" as Address;
+const validator = "11111111111111111111111111111112" as Address;
+
+function createDelegationAccountInfo(
+  validatorAddress: Address,
+  overrides: Partial<DelegationAccountInfo> = {},
+): DelegationAccountInfo {
+  const data = Buffer.alloc(40);
+  data.set(getAddressEncoder().encode(validatorAddress), 8);
+
+  return {
+    data: [
+      data.toString("base64"),
+      "base64",
+    ] as AccountInfoWithBase64EncodedData["data"],
+    executable: false,
+    lamports: lamports(BigInt(1)),
+    owner: DELEGATION_PROGRAM_ID,
+    space: BigInt(data.length),
+    ...overrides,
+  };
+}
+
+describe("parseDelegationRecordAccount", () => {
+  it("returns undelegated when the delegation record is missing", () => {
+    expect(parseDelegationRecordAccount(null)).toEqual({
+      status: DelegationStatus.Undelegated,
+    });
+  });
+
+  it("returns undelegated when the account has the wrong owner", () => {
+    expect(
+      parseDelegationRecordAccount(
+        createDelegationAccountInfo(validator, {
+          owner: SYSTEM_PROGRAM_ADDRESS,
+        }),
+      ),
+    ).toEqual({
+      status: DelegationStatus.Undelegated,
+    });
+  });
+
+  it("returns undelegated when the delegation record has zero lamports", () => {
+    expect(
+      parseDelegationRecordAccount(
+        createDelegationAccountInfo(validator, {
+          lamports: lamports(BigInt(0)),
+        }),
+      ),
+    ).toEqual({
+      status: DelegationStatus.Undelegated,
+    });
+  });
+
+  it("returns the delegated validator from the delegation record", () => {
+    const record = parseDelegationRecordAccount(
+      createDelegationAccountInfo(validator),
+    );
+
+    expect(record.status).toBe(DelegationStatus.Delegated);
+    if (record.status === DelegationStatus.Delegated) {
+      expect(record.validator).toBe(validator);
+    }
+  });
+});
+
+describe("getDelegationRecord", () => {
+  it("fetches and parses the derived delegation record", async () => {
+    const delegationRecord =
+      await delegationRecordPdaFromDelegatedAccount(delegatedAccount);
+    const getAccountInfo = vi.fn((address, config) => {
+      expect(address).toBe(delegationRecord);
+      expect(config).toEqual({
+        commitment: "processed",
+        encoding: "base64",
+      });
+      return {
+        send: vi.fn(async () => ({
+          value: createDelegationAccountInfo(validator),
+        })),
+      };
+    });
+
+    const record = await getDelegationRecord(
+      { getAccountInfo } as unknown as Rpc<SolanaRpcApiDevnet>,
+      delegatedAccount,
+      "processed",
+    );
+
+    expect(record.status).toBe(DelegationStatus.Delegated);
+    if (record.status === DelegationStatus.Delegated) {
+      expect(record.validator).toBe(validator);
+    }
+  });
+});

--- a/ts/kit/src/__test__/resolver.test.ts
+++ b/ts/kit/src/__test__/resolver.test.ts
@@ -20,8 +20,7 @@ import {
 
 type DelegationAccountInfo = AccountInfoBase & AccountInfoWithBase64EncodedData;
 
-const delegatedAccount =
-  "11111111111111111111111111111111" as Address;
+const delegatedAccount = "11111111111111111111111111111111" as Address;
 const validator = "11111111111111111111111111111112" as Address;
 
 function createDelegationAccountInfo(

--- a/ts/kit/src/resolver.ts
+++ b/ts/kit/src/resolver.ts
@@ -64,10 +64,13 @@ export async function getDelegationRecord(
   commitment: Commitment = "confirmed",
 ): Promise<DelegationRecord> {
   const accountInfo = await rpc
-    .getAccountInfo(await delegationRecordPdaFromDelegatedAccount(delegatedAccount), {
-      commitment,
-      encoding: "base64",
-    })
+    .getAccountInfo(
+      await delegationRecordPdaFromDelegatedAccount(delegatedAccount),
+      {
+        commitment,
+        encoding: "base64",
+      },
+    )
     .send();
   return parseDelegationRecordAccount(accountInfo.value);
 }

--- a/ts/kit/src/resolver.ts
+++ b/ts/kit/src/resolver.ts
@@ -1,7 +1,8 @@
 import {
   Address,
-  address,
   AccountInfoBase,
+  Commitment,
+  getAddressDecoder,
   lamports,
   getAddressEncoder,
   getProgramDerivedAddress,
@@ -13,12 +14,10 @@ import {
   Rpc,
   SolanaRpcApiDevnet,
   AccountInfoWithBase64EncodedData,
-  getStructCodec,
-  getAddressCodec,
-  getU8Codec,
   AccountRole,
 } from "@solana/kit";
 import { DELEGATION_PROGRAM_ID } from "./constants.js";
+import { delegationRecordPdaFromDelegatedAccount } from "./pda.js";
 
 /**
  * Interface representing the configuration for the connection resolver.
@@ -31,15 +30,47 @@ export interface Configuration {
 }
 
 /** Enumeration of possible delegation statuses */
-enum DelegationStatus {
+export enum DelegationStatus {
   Delegated,
   Undelegated,
 }
 
 /** Type representing a delegation record with status and optional validator information */
-type DelegationRecord =
+export type DelegationRecord =
   | { status: DelegationStatus.Delegated; validator: Address }
   | { status: DelegationStatus.Undelegated };
+
+export function parseDelegationRecordAccount(
+  account: (AccountInfoBase & AccountInfoWithBase64EncodedData) | null,
+): DelegationRecord {
+  const isDelegated =
+    account !== null &&
+    account.owner === DELEGATION_PROGRAM_ID &&
+    account.lamports !== lamports(BigInt(0));
+
+  return isDelegated
+    ? {
+        status: DelegationStatus.Delegated,
+        validator: getAddressDecoder().decode(
+          Buffer.from(account.data[0], "base64").subarray(8, 40),
+        ),
+      }
+    : { status: DelegationStatus.Undelegated };
+}
+
+export async function getDelegationRecord(
+  rpc: Rpc<SolanaRpcApiDevnet>,
+  delegatedAccount: Address,
+  commitment: Commitment = "confirmed",
+): Promise<DelegationRecord> {
+  const accountInfo = await rpc
+    .getAccountInfo(await delegationRecordPdaFromDelegatedAccount(delegatedAccount), {
+      commitment,
+      encoding: "base64",
+    })
+    .send();
+  return parseDelegationRecordAccount(accountInfo.value);
+}
 
 /** Class responsible for resolving connections to Solana validators */
 export class Resolver {
@@ -150,28 +181,8 @@ export class Resolver {
     account: (AccountInfoBase & AccountInfoWithBase64EncodedData) | null,
     pubkey: Address,
   ): DelegationRecord {
-    const isDelegated =
-      account !== null &&
-      account.owner === DELEGATION_PROGRAM_ID &&
-      account.lamports !== lamports(BigInt(0));
-
-    const record: DelegationRecord = isDelegated
-      ? {
-          status: DelegationStatus.Delegated,
-          validator: (() => {
-            const decodedData = delegationRecordCodec.decode(
-              Buffer.from(account.data[0], "base64"),
-            );
-            return address(decodedData.validator);
-          })(),
-        }
-      : { status: DelegationStatus.Undelegated };
+    const record = parseDelegationRecordAccount(account);
     this.delegations.set(pubkey.toString(), record);
     return record;
   }
 }
-
-const delegationRecordCodec = getStructCodec([
-  ["delegationStatus", getU8Codec()],
-  ["validator", getAddressCodec()],
-]);

--- a/ts/web3js/src/__test__/resolver.test.ts
+++ b/ts/web3js/src/__test__/resolver.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AccountInfo,
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+} from "@solana/web3.js";
+
+import { DELEGATION_PROGRAM_ID } from "../constants.js";
+import { delegationRecordPdaFromDelegatedAccount } from "../pda.js";
+import {
+  DelegationStatus,
+  getDelegationRecord,
+  parseDelegationRecordAccount,
+} from "../resolver.js";
+
+function createDelegationAccountInfo(
+  validator: PublicKey,
+  overrides: Partial<AccountInfo<Buffer>> = {},
+): AccountInfo<Buffer> {
+  const data = Buffer.alloc(40);
+  validator.toBuffer().copy(data, 8);
+
+  return {
+    data,
+    executable: false,
+    lamports: 1,
+    owner: DELEGATION_PROGRAM_ID,
+    rentEpoch: 0,
+    ...overrides,
+  };
+}
+
+describe("parseDelegationRecordAccount", () => {
+  it("returns undelegated when the delegation record is missing", () => {
+    expect(parseDelegationRecordAccount(null)).toEqual({
+      status: DelegationStatus.Undelegated,
+    });
+  });
+
+  it("returns undelegated when the account has the wrong owner", () => {
+    const validator = Keypair.generate().publicKey;
+
+    expect(
+      parseDelegationRecordAccount(
+        createDelegationAccountInfo(validator, {
+          owner: SystemProgram.programId,
+        }),
+      ),
+    ).toEqual({
+      status: DelegationStatus.Undelegated,
+    });
+  });
+
+  it("returns undelegated when the delegation record has zero lamports", () => {
+    const validator = Keypair.generate().publicKey;
+
+    expect(
+      parseDelegationRecordAccount(
+        createDelegationAccountInfo(validator, {
+          lamports: 0,
+        }),
+      ),
+    ).toEqual({
+      status: DelegationStatus.Undelegated,
+    });
+  });
+
+  it("returns the delegated validator from the delegation record", () => {
+    const validator = Keypair.generate().publicKey;
+    const record = parseDelegationRecordAccount(
+      createDelegationAccountInfo(validator),
+    );
+
+    expect(record.status).toBe(DelegationStatus.Delegated);
+    if (record.status === DelegationStatus.Delegated) {
+      expect(record.validator.toBase58()).toBe(validator.toBase58());
+    }
+  });
+});
+
+describe("getDelegationRecord", () => {
+  it("fetches and parses the derived delegation record", async () => {
+    const delegatedAccount = Keypair.generate().publicKey;
+    const validator = Keypair.generate().publicKey;
+    const delegationRecord =
+      delegationRecordPdaFromDelegatedAccount(delegatedAccount);
+    const getAccountInfo = vi.fn(async (address, commitment) => {
+      expect(address.toBase58()).toBe(delegationRecord.toBase58());
+      expect(commitment).toBe("processed");
+      return createDelegationAccountInfo(validator);
+    });
+
+    const record = await getDelegationRecord(
+      { getAccountInfo } as unknown as Connection,
+      delegatedAccount,
+      "processed",
+    );
+
+    expect(record.status).toBe(DelegationStatus.Delegated);
+    if (record.status === DelegationStatus.Delegated) {
+      expect(record.validator.toBase58()).toBe(validator.toBase58());
+    }
+  });
+});

--- a/ts/web3js/src/resolver.ts
+++ b/ts/web3js/src/resolver.ts
@@ -3,8 +3,10 @@ import {
   Connection,
   AccountInfo,
   Transaction,
+  Commitment,
 } from "@solana/web3.js";
 import { DELEGATION_PROGRAM_ID } from "./constants.js";
+import { delegationRecordPdaFromDelegatedAccount } from "./pda.js";
 /**
  * Interface representing the configuration for the connection resolver.
  */
@@ -16,15 +18,42 @@ export interface Configuration {
 }
 
 /** Enumeration of possible delegation statuses */
-enum DelegationStatus {
+export enum DelegationStatus {
   Delegated,
   Undelegated,
 }
 
 /** Type representing a delegation record with status and optional validator information */
-type DelegationRecord =
+export type DelegationRecord =
   | { status: DelegationStatus.Delegated; validator: PublicKey }
   | { status: DelegationStatus.Undelegated };
+
+export function parseDelegationRecordAccount(
+  account: AccountInfo<Buffer> | null,
+): DelegationRecord {
+  const isDelegated =
+    account !== null &&
+    account.owner.equals(DELEGATION_PROGRAM_ID) &&
+    account.lamports !== 0;
+  return isDelegated
+    ? {
+        status: DelegationStatus.Delegated,
+        validator: new PublicKey(account.data.subarray(8, 40)),
+      }
+    : { status: DelegationStatus.Undelegated };
+}
+
+export async function getDelegationRecord(
+  connection: Connection,
+  delegatedAccount: PublicKey,
+  commitment: Commitment = "confirmed",
+): Promise<DelegationRecord> {
+  const accountInfo = await connection.getAccountInfo(
+    delegationRecordPdaFromDelegatedAccount(delegatedAccount),
+    commitment,
+  );
+  return parseDelegationRecordAccount(accountInfo);
+}
 
 /** Class responsible for resolving connections to Solana validators */
 export class Resolver {
@@ -137,16 +166,7 @@ export class Resolver {
     account: AccountInfo<Buffer> | null,
     pubkey: PublicKey,
   ): DelegationRecord {
-    const isDelegated =
-      account !== null &&
-      account.owner.equals(DELEGATION_PROGRAM_ID) &&
-      account.lamports !== 0;
-    const record: DelegationRecord = isDelegated
-      ? {
-          status: DelegationStatus.Delegated,
-          validator: new PublicKey(account.data.subarray(8, 40)),
-        }
-      : { status: DelegationStatus.Undelegated };
+    const record = parseDelegationRecordAccount(account);
     this.delegations.set(pubkey.toString(), record);
     return record;
   }


### PR DESCRIPTION
## Summary
- Export delegation record status/types and helper functions from the web3.js resolver.
- Mirror the helper surface in the @solana/kit resolver and reuse it from resolver status updates.
- Add focused resolver tests for parsing delegated and undelegated records, plus fetching derived delegation records.

## Validation
- `npm test -- --run src/__test__/resolver.test.ts` in `ts/web3js`
- `npm run build` in `ts/kit`
- `npm test` in `ts/kit`