### PR TITLE
Fix private base transfer eATA setup

### DIFF
--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -1017,7 +1017,7 @@ describe("Exposed Instructions (@solana/kit)", () => {
     const validator = address(bs58.encode(nacl.sign.keyPair().publicKey));
 
     it("should use the shuttle private transfer instruction for private base-to-base transfers", async () => {
-      const [queue] = await deriveTransferQueue(mint, validator);
+      const [fromEphemeralAta] = await deriveEphemeralAta(from, mint);
       const instructions = await transferSpl(from, to, mint, 25n, {
         visibility: "private",
         fromBalance: "base",
@@ -1031,12 +1031,14 @@ describe("Exposed Instructions (@solana/kit)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(2);
-      expect(instructions[0].data?.[0]).toBe(28);
-      expect(instructions[0].accounts?.[1].address).toBe(queue);
-      const data = Buffer.from(instructions[1].data ?? []);
+      expect(instructions).toHaveLength(3);
+      expect(instructions[0].data?.[0]).toBe(0);
+      expect(instructions[0].accounts?.[0].address).toBe(fromEphemeralAta);
+      expect(instructions[1].data?.[0]).toBe(4);
+      expect(instructions[1].accounts?.[1].address).toBe(fromEphemeralAta);
+      const data = Buffer.from(instructions[2].data ?? []);
       expect(data[0]).toBe(25);
-      expect(instructions[1].accounts).toHaveLength(19);
+      expect(instructions[2].accounts).toHaveLength(19);
       expect(data.readUInt32LE(1)).toBe(7);
       expect(data.readBigUInt64LE(5)).toBe(25n);
 
@@ -1073,7 +1075,7 @@ describe("Exposed Instructions (@solana/kit)", () => {
         },
       });
 
-      const data = Buffer.from(instructions[1].data ?? []);
+      const data = Buffer.from(instructions[2].data ?? []);
       const [, nextOffset] = readLengthPrefixedField(data, 13);
       const [, suffixOffset] = readLengthPrefixedField(data, nextOffset);
       const [suffixField] = readLengthPrefixedField(data, suffixOffset);
@@ -1084,6 +1086,7 @@ describe("Exposed Instructions (@solana/kit)", () => {
     it("should initialize the destination ATA and vault when requested", async () => {
       const [vault] = await deriveVault(mint);
       const [vaultEphemeralAta] = await deriveEphemeralAta(vault, mint);
+      const [fromEphemeralAta] = await deriveEphemeralAta(from, mint);
 
       const instructions = await transferSpl(from, to, mint, 25n, {
         visibility: "private",
@@ -1100,11 +1103,14 @@ describe("Exposed Instructions (@solana/kit)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(5);
+      expect(instructions).toHaveLength(6);
       expect(instructions[2].accounts?.[1].address).toBe(vaultEphemeralAta);
       expect(instructions[2].data?.[0]).toBe(4);
-      expect(instructions[3].data?.[0]).toBe(28);
-      expect(instructions[4].data?.[0]).toBe(25);
+      expect(instructions[3].data?.[0]).toBe(0);
+      expect(instructions[3].accounts?.[0].address).toBe(fromEphemeralAta);
+      expect(instructions[4].data?.[0]).toBe(4);
+      expect(instructions[4].accounts?.[1].address).toBe(fromEphemeralAta);
+      expect(instructions[5].data?.[0]).toBe(25);
     });
 
     it("should prepend source ATA creation when initAtasIfMissing is set on base-source transfers", async () => {

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -37,7 +37,6 @@ import {
   depositAndQueueTransferIx,
   deriveTransferQueue,
   initTransferQueueIx,
-  processPendingTransferQueueRefillIx,
 } from "./transferQueue";
 import { encryptEd25519Recipient } from "./crypto";
 import {
@@ -1691,18 +1690,10 @@ export async function transferSpl(
     instructions.push(initVaultAtaIx(payer, fromAta, from, mint));
   }
 
-  const maybeRefillInstructions = async (): Promise<Instruction[]> => {
-    if (opts.fromBalance !== "base" || validator == null) {
-      return [];
-    }
-
-    const [queue] = await deriveTransferQueue(mint, validator);
-    return [await processPendingTransferQueueRefillIx(queue)];
-  };
-
   switch (opts.visibility) {
     case "private":
       if (opts.fromBalance === "base" && opts.toBalance === "base") {
+        const [fromEphemeralAta] = await deriveEphemeralAta(from, mint);
         const [shuttleEphemeralAta] = await deriveShuttleEphemeralAta(
           from,
           mint,
@@ -1716,7 +1707,8 @@ export async function transferSpl(
 
         return [
           ...instructions,
-          ...(await maybeRefillInstructions()),
+          initEphemeralAtaIx(fromEphemeralAta, from, mint, payer),
+          await delegateIx(payer, fromEphemeralAta, validator),
           await depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferIx(
             payer,
             shuttleEphemeralAta,

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -1047,7 +1047,7 @@ describe("Exposed Instructions (web3.js)", () => {
     const validator = Keypair.generate().publicKey;
 
     it("should use the shuttle private transfer instruction for private base-to-base transfers", async () => {
-      const [queue] = deriveTransferQueue(mint, validator);
+      const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
       const instructions = await transferSpl(from, to, mint, 25n, {
         visibility: "private",
         fromBalance: "base",
@@ -1061,12 +1061,18 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(2);
-      expect(instructions[0].data[0]).toBe(28);
-      expect(instructions[0].keys[1].pubkey.toBase58()).toBe(queue.toBase58());
-      const data = Buffer.from(instructions[1].data);
+      expect(instructions).toHaveLength(3);
+      expect(instructions[0].data[0]).toBe(0);
+      expect(instructions[0].keys[0].pubkey.toBase58()).toBe(
+        fromEphemeralAta.toBase58(),
+      );
+      expect(instructions[1].data[0]).toBe(4);
+      expect(instructions[1].keys[1].pubkey.toBase58()).toBe(
+        fromEphemeralAta.toBase58(),
+      );
+      const data = Buffer.from(instructions[2].data);
       expect(data[0]).toBe(25);
-      expect(instructions[1].keys).toHaveLength(19);
+      expect(instructions[2].keys).toHaveLength(19);
       expect(data.readUInt32LE(1)).toBe(7);
       expect(data.readBigUInt64LE(5)).toBe(25n);
 
@@ -1098,7 +1104,7 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      const data = Buffer.from(instructions[1].data);
+      const data = Buffer.from(instructions[2].data);
       const [suffixField] = readLengthPrefixedField(data, 14 + 80 + 1 + 32);
 
       expect(suffixField).toHaveLength(76);
@@ -1107,6 +1113,7 @@ describe("Exposed Instructions (web3.js)", () => {
     it("should initialize the destination ATA and vault when requested", async () => {
       const [vault] = deriveVault(mint);
       const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
+      const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
 
       const instructions = await transferSpl(from, to, mint, 25n, {
         visibility: "private",
@@ -1123,13 +1130,20 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(5);
+      expect(instructions).toHaveLength(6);
       expect(instructions[2].keys[1].pubkey.toBase58()).toBe(
         vaultEphemeralAta.toBase58(),
       );
       expect(instructions[2].data[0]).toBe(4);
-      expect(instructions[3].data[0]).toBe(28);
-      expect(instructions[4].data[0]).toBe(25);
+      expect(instructions[3].data[0]).toBe(0);
+      expect(instructions[3].keys[0].pubkey.toBase58()).toBe(
+        fromEphemeralAta.toBase58(),
+      );
+      expect(instructions[4].data[0]).toBe(4);
+      expect(instructions[4].keys[1].pubkey.toBase58()).toBe(
+        fromEphemeralAta.toBase58(),
+      );
+      expect(instructions[5].data[0]).toBe(25);
     });
 
     it("should prepend source ATA creation when initAtasIfMissing is set on base-source transfers", async () => {

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -31,6 +31,7 @@ import {
   deriveShuttleAta,
   deriveShuttleEphemeralAta,
   deriveVault,
+  deriveVaultAta,
   ensureTransferQueueCrankIx,
   initEphemeralAtaIx,
   initTransferQueueIx,
@@ -51,6 +52,7 @@ import {
   MAGIC_PROGRAM_ID,
   MAGIC_CONTEXT_ID,
   PERMISSION_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
 } from "../constants";
 import {
   delegateBufferPdaFromDelegatedAccountAndOwnerProgram,
@@ -881,6 +883,41 @@ describe("Exposed Instructions (web3.js)", () => {
       ).toBe(true);
     });
 
+    it("should use the token program override in idempotent flow", async () => {
+      const [vault] = deriveVault(mint);
+      const vaultAta = deriveVaultAta(mint, vault, TOKEN_2022_PROGRAM_ID);
+
+      const instructions = await delegateSpl(owner, mint, 1n, {
+        validator,
+        initVaultIfMissing: true,
+        initAtasIfMissing: true,
+        shuttleId: 7,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+      });
+      const setupAndDelegateInstruction = instructions.find(
+        (ix) => ix.data[0] === 24,
+      );
+
+      expect(instructions[0].keys[4].pubkey.toBase58()).toBe(
+        vaultAta.toBase58(),
+      );
+      expect(instructions[0].keys[5].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+      expect(instructions[1].keys[1].pubkey.toBase58()).toBe(
+        vaultAta.toBase58(),
+      );
+      expect(instructions[1].keys[5].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+      expect(setupAndDelegateInstruction?.keys[15].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+      expect(setupAndDelegateInstruction?.keys[18].pubkey.toBase58()).toBe(
+        vaultAta.toBase58(),
+      );
+    });
+
     it("should keep the shuttle eata writable in the zero-amount shuttle setup flow", async () => {
       const [shuttleEphemeralAta] = deriveShuttleEphemeralAta(owner, mint, 7);
       const [shuttleAta] = deriveShuttleAta(shuttleEphemeralAta, mint);
@@ -976,6 +1013,25 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(withdrawInstruction).toBeDefined();
       expect(withdrawInstruction?.keys).toHaveLength(16);
       expect(instructions.find((ix) => ix.data[0] === 3)).toBeUndefined();
+    });
+
+    it("should use the token program override when idempotent", async () => {
+      const instructions = await withdrawSpl(owner, mint, 1n, {
+        validator,
+        initAtasIfMissing: true,
+        shuttleId: 7,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+      });
+
+      const ataInstruction = instructions.find(
+        (ix) => ix.keys[5]?.pubkey.equals(TOKEN_2022_PROGRAM_ID),
+      );
+      const withdrawInstruction = instructions.find((ix) => ix.data[0] === 26);
+
+      expect(ataInstruction).toBeDefined();
+      expect(withdrawInstruction?.keys[15].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
     });
 
     it("should fall back to the legacy withdraw instruction when idempotent is false", async () => {
@@ -1144,6 +1200,46 @@ describe("Exposed Instructions (web3.js)", () => {
         fromEphemeralAta.toBase58(),
       );
       expect(instructions[5].data[0]).toBe(25);
+    });
+
+    it("should use the token program override when initializing the vault", async () => {
+      const [vault] = deriveVault(mint);
+      const vaultAta = deriveVaultAta(mint, vault, TOKEN_2022_PROGRAM_ID);
+
+      const instructions = await transferSpl(from, to, mint, 25n, {
+        visibility: "private",
+        fromBalance: "base",
+        toBalance: "base",
+        validator,
+        shuttleId: 7,
+        initVaultIfMissing: true,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+        privateTransfer: {
+          minDelayMs: 100n,
+          maxDelayMs: 300n,
+          split: 4,
+        },
+      });
+
+      expect(instructions).toHaveLength(6);
+      expect(instructions[0].keys[4].pubkey.toBase58()).toBe(
+        vaultAta.toBase58(),
+      );
+      expect(instructions[0].keys[5].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+      expect(instructions[1].keys[1].pubkey.toBase58()).toBe(
+        vaultAta.toBase58(),
+      );
+      expect(instructions[1].keys[5].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+      expect(instructions[5].keys[14].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+      expect(instructions[5].keys[17].pubkey.toBase58()).toBe(
+        vaultAta.toBase58(),
+      );
     });
 
     it("should prepend source ATA creation when initAtasIfMissing is set on base-source transfers", async () => {
@@ -1642,6 +1738,25 @@ describe("Exposed Instructions (web3.js)", () => {
         deriveEphemeralAta(vault, mint)[0].toBase58(),
       );
     });
+
+    it("should accept a token program override", () => {
+      const vault = new PublicKey("11111111111111111111111111111113");
+      const mint = new PublicKey("11111111111111111111111111111114");
+      const payer = new PublicKey("11111111111111111111111111111115");
+      const instruction = initVaultIx(
+        vault,
+        mint,
+        payer,
+        TOKEN_2022_PROGRAM_ID,
+      );
+
+      expect(instruction.keys[4].pubkey.toBase58()).toBe(
+        deriveVaultAta(mint, vault, TOKEN_2022_PROGRAM_ID).toBase58(),
+      );
+      expect(instruction.keys[5].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+    });
   });
 
   describe("withdrawSplIx (Ephemeral SPL Token Program)", () => {
@@ -1653,6 +1768,25 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(instruction.data).toHaveLength(9);
       expect(instruction.data[0]).toBe(3);
       expect(Buffer.from(instruction.data).readBigUInt64LE(1)).toBe(1n);
+    });
+
+    it("should accept a token program override", () => {
+      const owner = new PublicKey("11111111111111111111111111111113");
+      const mint = new PublicKey("11111111111111111111111111111114");
+      const [vault] = deriveVault(mint);
+      const instruction = withdrawSplIx(
+        owner,
+        mint,
+        1n,
+        TOKEN_2022_PROGRAM_ID,
+      );
+
+      expect(instruction.keys[4].pubkey.toBase58()).toBe(
+        deriveVaultAta(mint, vault, TOKEN_2022_PROGRAM_ID).toBase58(),
+      );
+      expect(instruction.keys[6].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
     });
   });
 

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -1023,8 +1023,8 @@ describe("Exposed Instructions (web3.js)", () => {
         tokenProgram: TOKEN_2022_PROGRAM_ID,
       });
 
-      const ataInstruction = instructions.find(
-        (ix) => ix.keys[5]?.pubkey.equals(TOKEN_2022_PROGRAM_ID),
+      const ataInstruction = instructions.find((ix) =>
+        ix.keys[5]?.pubkey.equals(TOKEN_2022_PROGRAM_ID),
       );
       const withdrawInstruction = instructions.find((ix) => ix.data[0] === 26);
 
@@ -1774,12 +1774,7 @@ describe("Exposed Instructions (web3.js)", () => {
       const owner = new PublicKey("11111111111111111111111111111113");
       const mint = new PublicKey("11111111111111111111111111111114");
       const [vault] = deriveVault(mint);
-      const instruction = withdrawSplIx(
-        owner,
-        mint,
-        1n,
-        TOKEN_2022_PROGRAM_ID,
-      );
+      const instruction = withdrawSplIx(owner, mint, 1n, TOKEN_2022_PROGRAM_ID);
 
       expect(instruction.keys[4].pubkey.toBase58()).toBe(
         deriveVaultAta(mint, vault, TOKEN_2022_PROGRAM_ID).toBase58(),

--- a/ts/web3js/src/constants.ts
+++ b/ts/web3js/src/constants.ts
@@ -27,6 +27,10 @@ export const TOKEN_PROGRAM_ID = new PublicKey(
   "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
 );
 
+export const TOKEN_2022_PROGRAM_ID = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+);
+
 export const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
   "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
 );

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -24,7 +24,6 @@ import {
   depositAndQueueTransferIx,
   deriveTransferQueue,
   initTransferQueueIx,
-  processPendingTransferQueueRefillIx,
   toTransactionInstruction,
 } from "./transferQueue.js";
 import { encryptWithEd25519Recipient, ENCRYPTION_OVERHEAD } from "./crypto.js";
@@ -1789,18 +1788,10 @@ export async function transferSpl(
     );
   }
 
-  const maybeRefillInstructions = (): TransactionInstruction[] => {
-    if (opts.fromBalance !== "base" || validator == null) {
-      return [];
-    }
-
-    const [queue] = deriveTransferQueue(mint, validator);
-    return [processPendingTransferQueueRefillIx(queue)];
-  };
-
   switch (opts.visibility) {
     case "private":
       if (opts.fromBalance === "base" && opts.toBalance === "base") {
+        const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
         const [shuttleEphemeralAta] = deriveShuttleEphemeralAta(
           from,
           mint,
@@ -1814,7 +1805,8 @@ export async function transferSpl(
 
         return [
           ...instructions,
-          ...maybeRefillInstructions(),
+          initEphemeralAtaIx(fromEphemeralAta, from, mint, payer),
+          delegateEphemeralAtaIx(payer, fromEphemeralAta, validator),
           depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferIx(
             payer,
             shuttleEphemeralAta,

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -308,8 +308,12 @@ export function deriveLamportsPda(
  * @param vault - The vault account
  * @returns The vault ATA account
  */
-export function deriveVaultAta(mint: PublicKey, vault: PublicKey): PublicKey {
-  return getAssociatedTokenAddressSync(mint, vault, true);
+export function deriveVaultAta(
+  mint: PublicKey,
+  vault: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
+): PublicKey {
+  return getAssociatedTokenAddressSync(mint, vault, true, tokenProgram);
 }
 
 /**
@@ -366,8 +370,14 @@ export function deriveShuttleAta(
 export function deriveShuttleWalletAta(
   mint: PublicKey,
   shuttleEphemeralAta: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): PublicKey {
-  return getAssociatedTokenAddressSync(mint, shuttleEphemeralAta, true);
+  return getAssociatedTokenAddressSync(
+    mint,
+    shuttleEphemeralAta,
+    true,
+    tokenProgram,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -414,12 +424,14 @@ export function initVaultAtaIx(
   vaultAta: PublicKey,
   vault: PublicKey,
   mint: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   return createAssociatedTokenAccountIdempotentInstruction(
     payer,
     vaultAta,
     vault,
     mint,
+    tokenProgram,
   );
 }
 
@@ -434,9 +446,10 @@ export function initVaultIx(
   vault: PublicKey,
   mint: PublicKey,
   payer: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
-  const vaultAta = deriveVaultAta(mint, vault);
+  const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
   return new TransactionInstruction({
     programId: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
     keys: [
@@ -445,7 +458,7 @@ export function initVaultIx(
       { pubkey: mint, isSigner: false, isWritable: false },
       { pubkey: vaultEphemeralAta, isSigner: false, isWritable: true },
       { pubkey: vaultAta, isSigner: false, isWritable: true },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       {
         pubkey: ASSOCIATED_TOKEN_PROGRAM_ID,
         isSigner: false,
@@ -497,6 +510,7 @@ export function transferToVaultIx(
   vaultAta: PublicKey,
   owner: PublicKey,
   amount: bigint,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   return new TransactionInstruction({
     programId: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
@@ -507,7 +521,7 @@ export function transferToVaultIx(
       { pubkey: sourceAta, isSigner: false, isWritable: true },
       { pubkey: vaultAta, isSigner: false, isWritable: true },
       { pubkey: owner, isSigner: true, isWritable: false },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
     ],
     data: encodeAmountInstructionData(2, amount),
   });
@@ -525,6 +539,7 @@ export function depositSplTokensIx(
   vaultAta: PublicKey,
   owner: PublicKey,
   amount: bigint,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   return transferToVaultIx(
     ephemeralAta,
@@ -534,6 +549,7 @@ export function depositSplTokensIx(
     vaultAta,
     owner,
     amount,
+    tokenProgram,
   );
 }
 
@@ -607,6 +623,7 @@ export function initShuttleEphemeralAtaIx(
   owner: PublicKey,
   mint: PublicKey,
   shuttleId: number,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   if (
     !Number.isInteger(shuttleId) ||
@@ -629,7 +646,7 @@ export function initShuttleEphemeralAtaIx(
       { pubkey: shuttleWalletAta, isSigner: false, isWritable: true },
       { pubkey: owner, isSigner: false, isWritable: false },
       { pubkey: mint, isSigner: false, isWritable: false },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       {
         pubkey: ASSOCIATED_TOKEN_PROGRAM_ID,
         isSigner: false,
@@ -725,6 +742,7 @@ export function setupAndDelegateShuttleEphemeralAtaWithMergeIx(
   shuttleId: number,
   amount: bigint,
   validator?: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   if (
     !Number.isInteger(shuttleId) ||
@@ -736,7 +754,7 @@ export function setupAndDelegateShuttleEphemeralAtaWithMergeIx(
 
   const [rentPda] = deriveRentPda();
   const [vault] = deriveVault(mint);
-  const vaultAta = deriveVaultAta(mint, vault);
+  const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
 
   const data = validator ? Buffer.alloc(45) : Buffer.alloc(13);
   data[0] = 24;
@@ -787,7 +805,7 @@ export function setupAndDelegateShuttleEphemeralAtaWithMergeIx(
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       { pubkey: destinationAta, isSigner: false, isWritable: true },
       { pubkey: mint, isSigner: false, isWritable: false },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       { pubkey: vault, isSigner: false, isWritable: false },
       { pubkey: sourceAta, isSigner: false, isWritable: true },
       { pubkey: vaultAta, isSigner: false, isWritable: true },
@@ -819,6 +837,7 @@ export function depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer
   split: number,
   validator?: PublicKey,
   clientRefId?: bigint,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   if (
     !Number.isInteger(shuttleId) ||
@@ -847,7 +866,7 @@ export function depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer
 
   const [rentPda] = deriveRentPda();
   const [vault] = deriveVault(mint);
-  const vaultAta = deriveVaultAta(mint, vault);
+  const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
   const [queue] = deriveTransferQueue(mint, validator);
   const encryptedDestination = encryptWithEd25519Recipient(
     destinationOwner.toBytes(),
@@ -914,7 +933,7 @@ export function depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer
       },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       { pubkey: mint, isSigner: false, isWritable: false },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       { pubkey: vault, isSigner: false, isWritable: false },
       { pubkey: sourceAta, isSigner: false, isWritable: true },
       { pubkey: vaultAta, isSigner: false, isWritable: true },
@@ -939,6 +958,7 @@ export function withdrawThroughDelegatedShuttleWithMergeIx(
   shuttleId: number,
   amount: bigint,
   validator?: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   if (
     !Number.isInteger(shuttleId) ||
@@ -1001,7 +1021,7 @@ export function withdrawThroughDelegatedShuttleWithMergeIx(
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       { pubkey: ownerAta, isSigner: false, isWritable: true },
       { pubkey: mint, isSigner: false, isWritable: false },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
     ],
     data,
   });
@@ -1096,6 +1116,7 @@ export function mergeShuttleIntoAtaIx(
   shuttleEphemeralAta: PublicKey,
   shuttleWalletAta: PublicKey,
   mint: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   return new TransactionInstruction({
     programId: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
@@ -1105,7 +1126,7 @@ export function mergeShuttleIntoAtaIx(
       { pubkey: shuttleEphemeralAta, isSigner: false, isWritable: false },
       { pubkey: shuttleWalletAta, isSigner: false, isWritable: true },
       { pubkey: mint, isSigner: false, isWritable: false },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
     ],
     data: Buffer.from([15]),
   });
@@ -1129,6 +1150,7 @@ export function undelegateAndCloseShuttleEphemeralAtaIx(
   shuttleWalletAta: PublicKey,
   destinationAta: PublicKey,
   escrowIndex?: number,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   const data =
     escrowIndex === undefined
@@ -1144,7 +1166,7 @@ export function undelegateAndCloseShuttleEphemeralAtaIx(
       { pubkey: shuttleAta, isSigner: false, isWritable: false },
       { pubkey: shuttleWalletAta, isSigner: false, isWritable: true },
       { pubkey: destinationAta, isSigner: false, isWritable: true },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       { pubkey: MAGIC_CONTEXT_ID, isSigner: false, isWritable: true },
       { pubkey: MAGIC_PROGRAM_ID, isSigner: false, isWritable: false },
     ],
@@ -1163,11 +1185,17 @@ export function withdrawSplIx(
   owner: PublicKey,
   mint: PublicKey,
   amount: bigint,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
   const [vault] = deriveVault(mint);
-  const vaultAta = deriveVaultAta(mint, vault);
-  const userDestAta = getAssociatedTokenAddressSync(mint, owner);
+  const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
+  const userDestAta = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    false,
+    tokenProgram,
+  );
 
   return new TransactionInstruction({
     programId: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
@@ -1178,7 +1206,7 @@ export function withdrawSplIx(
       { pubkey: mint, isSigner: false, isWritable: false },
       { pubkey: vaultAta, isSigner: false, isWritable: true },
       { pubkey: userDestAta, isSigner: false, isWritable: true },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
     ],
     // [WITHDRAW_OPCODE, amount(le u64)]
     data: encodeAmountInstructionData(3, amount),
@@ -1366,6 +1394,7 @@ export function undelegateEataPermissionIx(
 export interface DelegateSplOptions {
   payer?: PublicKey;
   validator?: PublicKey;
+  tokenProgram?: PublicKey;
   initIfMissing?: boolean;
   initVaultIfMissing?: boolean;
   initAtasIfMissing?: boolean;
@@ -1406,6 +1435,7 @@ export interface TransferSplOptions {
   toBalance: TransferBalance;
   payer?: PublicKey;
   validator?: PublicKey;
+  tokenProgram?: PublicKey;
   initIfMissing?: boolean;
   initAtasIfMissing?: boolean;
   initVaultIfMissing?: boolean;
@@ -1431,6 +1461,7 @@ async function buildDelegateSplInstructions(
 ): Promise<TransactionInstruction[]> {
   const payer = opts?.payer ?? owner;
   const validator = opts?.validator;
+  const tokenProgram = opts?.tokenProgram ?? TOKEN_PROGRAM_ID;
   const initIfMissing = opts?.initIfMissing ?? true;
   const initVaultIfMissing = opts?.initVaultIfMissing ?? initIfMissing;
   const isPrivate = opts?.private ?? false;
@@ -1440,8 +1471,13 @@ async function buildDelegateSplInstructions(
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
   const [vault] = deriveVault(mint);
   const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
-  const vaultAta = deriveVaultAta(mint, vault);
-  const ownerAta = getAssociatedTokenAddressSync(mint, owner);
+  const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
+  const ownerAta = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    false,
+    tokenProgram,
+  );
 
   if (initIfMissing) {
     instructions.push(initEphemeralAtaIx(ephemeralAta, owner, mint, payer));
@@ -1449,8 +1485,8 @@ async function buildDelegateSplInstructions(
 
   if (initVaultIfMissing) {
     instructions.push(
-      initVaultIx(vault, mint, payer),
-      initVaultAtaIx(payer, vaultAta, vault, mint),
+      initVaultIx(vault, mint, payer, tokenProgram),
+      initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
       delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
@@ -1464,6 +1500,7 @@ async function buildDelegateSplInstructions(
       vaultAta,
       owner,
       amount,
+      tokenProgram,
     ),
   );
 
@@ -1484,6 +1521,7 @@ async function buildIdempotentDelegateSplInstructions(
 ): Promise<TransactionInstruction[]> {
   const payer = opts?.payer ?? owner;
   const validator = opts?.validator;
+  const tokenProgram = opts?.tokenProgram ?? TOKEN_PROGRAM_ID;
   const initIfMissing = opts?.initIfMissing ?? true;
   const initVaultIfMissing = opts?.initVaultIfMissing ?? false;
   const initAtasIfMissing = opts?.initAtasIfMissing ?? false;
@@ -1495,8 +1533,13 @@ async function buildIdempotentDelegateSplInstructions(
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
   const [vault] = deriveVault(mint);
   const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
-  const vaultAta = deriveVaultAta(mint, vault);
-  const ownerAta = getAssociatedTokenAddressSync(mint, owner);
+  const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
+  const ownerAta = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    false,
+    tokenProgram,
+  );
 
   const [shuttleEphemeralAta] = deriveShuttleEphemeralAta(
     owner,
@@ -1504,12 +1547,16 @@ async function buildIdempotentDelegateSplInstructions(
     shuttleId,
   );
   const [shuttleAta] = deriveShuttleAta(shuttleEphemeralAta, mint);
-  const shuttleWalletAta = deriveShuttleWalletAta(mint, shuttleEphemeralAta);
+  const shuttleWalletAta = deriveShuttleWalletAta(
+    mint,
+    shuttleEphemeralAta,
+    tokenProgram,
+  );
 
   if (initVaultIfMissing) {
     instructions.push(
-      initVaultIx(vault, mint, payer),
-      initVaultAtaIx(payer, vaultAta, vault, mint),
+      initVaultIx(vault, mint, payer, tokenProgram),
+      initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
       delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
@@ -1521,6 +1568,7 @@ async function buildIdempotentDelegateSplInstructions(
         ownerAta,
         owner,
         mint,
+        tokenProgram,
       ),
     );
   }
@@ -1549,6 +1597,7 @@ async function buildIdempotentDelegateSplInstructions(
         shuttleId,
         amount,
         validator,
+        tokenProgram,
       ),
     );
   } else {
@@ -1561,6 +1610,7 @@ async function buildIdempotentDelegateSplInstructions(
         owner,
         mint,
         shuttleId,
+        tokenProgram,
       ),
       delegateShuttleEphemeralAtaIx(
         payer,
@@ -1602,6 +1652,7 @@ export async function delegateSplWithPrivateTransfer(
 ): Promise<TransactionInstruction[]> {
   const payer = opts?.payer ?? owner;
   const validator = opts?.validator;
+  const tokenProgram = opts?.tokenProgram ?? TOKEN_PROGRAM_ID;
   const initIfMissing = opts?.initIfMissing ?? true;
   const initVaultIfMissing = opts?.initVaultIfMissing ?? false;
   const initAtasIfMissing = opts?.initAtasIfMissing ?? false;
@@ -1622,21 +1673,30 @@ export async function delegateSplWithPrivateTransfer(
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
   const [vault] = deriveVault(mint);
   const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
-  const vaultAta = deriveVaultAta(mint, vault);
+  const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
   const [queue] = deriveTransferQueue(mint, validator);
-  const ownerAta = getAssociatedTokenAddressSync(mint, owner);
+  const ownerAta = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    false,
+    tokenProgram,
+  );
   const [shuttleEphemeralAta] = deriveShuttleEphemeralAta(
     owner,
     mint,
     shuttleId,
   );
   const [shuttleAta] = deriveShuttleAta(shuttleEphemeralAta, mint);
-  const shuttleWalletAta = deriveShuttleWalletAta(mint, shuttleEphemeralAta);
+  const shuttleWalletAta = deriveShuttleWalletAta(
+    mint,
+    shuttleEphemeralAta,
+    tokenProgram,
+  );
 
   if (initVaultIfMissing) {
     instructions.push(
-      initVaultIx(vault, mint, payer),
-      initVaultAtaIx(payer, vaultAta, vault, mint),
+      initVaultIx(vault, mint, payer, tokenProgram),
+      initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
       delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
@@ -1656,6 +1716,7 @@ export async function delegateSplWithPrivateTransfer(
         ownerAta,
         owner,
         mint,
+        tokenProgram,
       ),
     );
   }
@@ -1683,6 +1744,7 @@ export async function delegateSplWithPrivateTransfer(
       split,
       validator,
       clientRefId,
+      tokenProgram,
     ),
   );
 
@@ -1698,6 +1760,7 @@ export async function transferSpl(
 ): Promise<TransactionInstruction[]> {
   const payer = opts.payer ?? from;
   const validator = opts.validator;
+  const tokenProgram = opts.tokenProgram ?? TOKEN_PROGRAM_ID;
   const initIfMissing = opts.initIfMissing ?? false;
   const initAtasIfMissing = opts.initAtasIfMissing ?? false;
   const initVaultIfMissing = opts.initVaultIfMissing ?? false;
@@ -1710,8 +1773,13 @@ export async function transferSpl(
 
   console.log("opts: ", opts);
 
-  const fromAta = getAssociatedTokenAddressSync(mint, from);
-  const toAta = getAssociatedTokenAddressSync(mint, to);
+  const fromAta = getAssociatedTokenAddressSync(
+    mint,
+    from,
+    false,
+    tokenProgram,
+  );
+  const toAta = getAssociatedTokenAddressSync(mint, to, false, tokenProgram);
 
   if (opts.fromBalance === "ephemeral") {
     switch (opts.visibility) {
@@ -1725,7 +1793,7 @@ export async function transferSpl(
 
           const [queue] = deriveTransferQueue(mint, validator);
           const [vault] = deriveVault(mint);
-          const vaultAta = deriveVaultAta(mint, vault);
+          const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
 
           return [
             toTransactionInstruction(
@@ -1743,20 +1811,39 @@ export async function transferSpl(
                 split,
                 undefined,
                 clientRefId,
+                tokenProgram,
               ),
             ),
           ];
         }
 
         if (opts.toBalance === "ephemeral") {
-          return [createTransferInstruction(fromAta, toAta, from, amount)];
+          return [
+            createTransferInstruction(
+              fromAta,
+              toAta,
+              from,
+              amount,
+              [],
+              tokenProgram,
+            ),
+          ];
         }
 
         break;
 
       case "public":
         if (opts.toBalance === "ephemeral") {
-          return [createTransferInstruction(fromAta, toAta, from, amount)];
+          return [
+            createTransferInstruction(
+              fromAta,
+              toAta,
+              from,
+              amount,
+              [],
+              tokenProgram,
+            ),
+          ];
         }
 
         break;
@@ -1768,11 +1855,11 @@ export async function transferSpl(
   if (initVaultIfMissing) {
     const [vault] = deriveVault(mint);
     const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
-    const vaultAta = deriveVaultAta(mint, vault);
+    const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
 
     instructions.push(
-      initVaultIx(vault, mint, payer),
-      initVaultAtaIx(payer, vaultAta, vault, mint),
+      initVaultIx(vault, mint, payer, tokenProgram),
+      initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
       delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
@@ -1784,6 +1871,7 @@ export async function transferSpl(
         fromAta,
         from,
         mint,
+        tokenProgram,
       ),
     );
   }
@@ -1801,6 +1889,7 @@ export async function transferSpl(
         const shuttleWalletAta = deriveShuttleWalletAta(
           mint,
           shuttleEphemeralAta,
+          tokenProgram,
         );
 
         return [
@@ -1824,6 +1913,7 @@ export async function transferSpl(
             split,
             validator,
             clientRefId,
+            tokenProgram,
           ),
         ];
       }
@@ -1838,6 +1928,7 @@ export async function transferSpl(
               toAta,
               to,
               mint,
+              tokenProgram,
             ),
             initEphemeralAtaIx(toEphemeralAta, to, mint, payer),
             delegateEphemeralAtaIx(payer, toEphemeralAta, validator),
@@ -1853,6 +1944,7 @@ export async function transferSpl(
         const shuttleWalletAta = deriveShuttleWalletAta(
           mint,
           shuttleEphemeralAta,
+          tokenProgram,
         );
 
         return [
@@ -1869,6 +1961,7 @@ export async function transferSpl(
             shuttleId,
             amount,
             validator,
+            tokenProgram,
           ),
         ];
       }
@@ -1880,7 +1973,14 @@ export async function transferSpl(
       if (opts.fromBalance === "base" && opts.toBalance === "base") {
         return [
           ...instructions,
-          createTransferInstruction(fromAta, toAta, from, amount),
+          createTransferInstruction(
+            fromAta,
+            toAta,
+            from,
+            amount,
+            [],
+            tokenProgram,
+          ),
         ];
       }
 
@@ -1901,6 +2001,7 @@ async function buildIdempotentWithdrawSplInstructions(
 ): Promise<TransactionInstruction[]> {
   const payer = opts?.payer ?? owner;
   const validator = opts?.validator;
+  const tokenProgram = opts?.tokenProgram ?? TOKEN_PROGRAM_ID;
   const initIfMissing = opts?.initIfMissing ?? true;
   const initAtasIfMissing = opts?.initAtasIfMissing ?? false;
   const shuttleId = opts?.shuttleId ?? randomShuttleId();
@@ -1908,14 +2009,23 @@ async function buildIdempotentWithdrawSplInstructions(
   const instructions: TransactionInstruction[] = [];
 
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
-  const ownerAta = getAssociatedTokenAddressSync(mint, owner);
+  const ownerAta = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    false,
+    tokenProgram,
+  );
   const [shuttleEphemeralAta] = deriveShuttleEphemeralAta(
     owner,
     mint,
     shuttleId,
   );
   const [shuttleAta] = deriveShuttleAta(shuttleEphemeralAta, mint);
-  const shuttleWalletAta = deriveShuttleWalletAta(mint, shuttleEphemeralAta);
+  const shuttleWalletAta = deriveShuttleWalletAta(
+    mint,
+    shuttleEphemeralAta,
+    tokenProgram,
+  );
 
   if (initAtasIfMissing) {
     instructions.push(
@@ -1924,6 +2034,7 @@ async function buildIdempotentWithdrawSplInstructions(
         ownerAta,
         owner,
         mint,
+        tokenProgram,
       ),
     );
   }
@@ -1945,6 +2056,7 @@ async function buildIdempotentWithdrawSplInstructions(
       shuttleId,
       amount,
       validator,
+      tokenProgram,
     ),
   );
 
@@ -1957,21 +2069,29 @@ export async function withdrawSpl(
   amount: bigint,
   opts?: WithdrawSplOptions,
 ): Promise<TransactionInstruction[]> {
+  const tokenProgram = opts?.tokenProgram ?? TOKEN_PROGRAM_ID;
+
   if (opts?.idempotent === false) {
     const instructions: TransactionInstruction[] = [];
     if (opts?.initAtasIfMissing === true) {
       const payer = opts.payer ?? owner;
-      const ownerAta = getAssociatedTokenAddressSync(mint, owner);
+      const ownerAta = getAssociatedTokenAddressSync(
+        mint,
+        owner,
+        false,
+        tokenProgram,
+      );
       instructions.push(
         createAssociatedTokenAccountIdempotentInstruction(
           payer,
           ownerAta,
           owner,
           mint,
+          tokenProgram,
         ),
       );
     }
-    instructions.push(withdrawSplIx(owner, mint, amount));
+    instructions.push(withdrawSplIx(owner, mint, amount, tokenProgram));
     return instructions;
   }
 

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -157,6 +157,7 @@ export function depositAndQueueTransferIx(
   split: number = 1,
   reimbursementTokenInfo: PublicKey = source,
   clientRefId?: bigint,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   if (!Number.isInteger(split) || split <= 0 || split > 0xffff_ffff) {
     throw new Error("split must fit in u32");
@@ -193,7 +194,7 @@ export function depositAndQueueTransferIx(
       { pubkey: vaultAta, isSigner: false, isWritable: true },
       { pubkey: destination, isSigner: false, isWritable: false },
       { pubkey: owner, isSigner: true, isWritable: false },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       { pubkey: reimbursementTokenInfo, isSigner: false, isWritable: true },
     ],
     data: new Uint8Array(data),


### PR DESCRIPTION
## Summary

- initialize and delegate the sender eATA before private base-to-base shuttle transfers
- stop prepending ExecutePendingTransferQueueRefill to that transfer transaction
- apply the same transfer layout in both web3js and kit SDKs

## Validation

- npm run build in ts/web3js
- npm run build in ts/kit
- ./node_modules/.bin/vitest run src/__test__/instructions.test.ts src/__test__/lookup-table.test.ts in ts/web3js
- ./node_modules/.bin/vitest run src/__test__/instructions.test.ts in ts/kit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified private base-to-base transfer flow by removing redundant refill steps and reorganizing the instruction sequence for more predictable behavior.
* **Compatibility**
  * Added optional token-program selection to token flows, enabling support for alternate token program IDs.
* **Chores**
  * Introduced a new token program identifier constant for broader program support.
* **Tests**
  * Updated and added tests to reflect the new instruction ordering and token-program wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/ephemeral-rollups-sdk/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->