### PR TITLE
Apply queue ATA support across SDKs

### DIFF
--- a/rust/sdk/src/spl/builders/initialize_transfer_queue.rs
+++ b/rust/sdk/src/spl/builders/initialize_transfer_queue.rs
@@ -1,7 +1,18 @@
 use crate::{
     compat,
-    consts::{ESPL_TOKEN_PROGRAM_ID, PERMISSION_PROGRAM_ID},
-    spl::{find_transfer_queue, EphemeralSplDiscriminator},
+    consts::{
+        ASSOCIATED_TOKEN_PROGRAM_ID, ESPL_TOKEN_PROGRAM_ID, PERMISSION_PROGRAM_ID, TOKEN_PROGRAM_ID,
+    },
+    cpi::DELEGATION_PROGRAM_ID,
+    pda::{
+        delegate_buffer_pda_from_delegated_account_and_owner_program,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+    },
+    spl::{
+        find_transfer_queue, find_transfer_queue_ephemeral_ata, find_transfer_queue_vault_ata,
+        EphemeralSplDiscriminator,
+    },
 };
 
 const PERMISSION_SEED: &[u8] = b"permission:";
@@ -21,6 +32,17 @@ impl InitializeTransferQueueBuilder {
             &[PERMISSION_SEED, queue.as_ref()],
             &PERMISSION_PROGRAM_ID,
         );
+        let (queue_ephemeral_ata, _queue_eata_bump) =
+            find_transfer_queue_ephemeral_ata(&self.mint, &self.validator);
+        let queue_vault_ata =
+            find_transfer_queue_vault_ata(&self.mint, &self.validator, &TOKEN_PROGRAM_ID);
+        let delegation_buffer = delegate_buffer_pda_from_delegated_account_and_owner_program(
+            &queue_ephemeral_ata,
+            &ESPL_TOKEN_PROGRAM_ID,
+        );
+        let delegation_record = delegation_record_pda_from_delegated_account(&queue_ephemeral_ata);
+        let delegation_metadata =
+            delegation_metadata_pda_from_delegated_account(&queue_ephemeral_ata);
 
         let mut data = Vec::with_capacity(5);
         data.push(EphemeralSplDiscriminator::InitializeTransferQueue as u8);
@@ -41,6 +63,15 @@ impl InitializeTransferQueueBuilder {
                     false,
                 ),
                 compat::AccountMeta::new_readonly(PERMISSION_PROGRAM_ID, false),
+                compat::AccountMeta::new(queue_ephemeral_ata, false),
+                compat::AccountMeta::new(queue_vault_ata, false),
+                compat::AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
+                compat::AccountMeta::new_readonly(ASSOCIATED_TOKEN_PROGRAM_ID, false),
+                compat::AccountMeta::new_readonly(ESPL_TOKEN_PROGRAM_ID, false),
+                compat::AccountMeta::new(delegation_buffer, false),
+                compat::AccountMeta::new(delegation_record, false),
+                compat::AccountMeta::new(delegation_metadata, false),
+                compat::AccountMeta::new_readonly(DELEGATION_PROGRAM_ID, false),
             ],
             data,
         }

--- a/rust/sdk/src/spl/types.rs
+++ b/rust/sdk/src/spl/types.rs
@@ -151,6 +151,23 @@ pub fn find_transfer_queue(
     )
 }
 
+pub fn find_transfer_queue_ephemeral_ata(
+    mint: &compat::Pubkey,
+    validator: &compat::Pubkey,
+) -> (compat::Pubkey, u8) {
+    let (queue, _queue_bump) = find_transfer_queue(mint, validator);
+    compat::Pubkey::find_program_address(&[queue.as_ref(), mint.as_ref()], &ESPL_TOKEN_PROGRAM_ID)
+}
+
+pub fn find_transfer_queue_vault_ata(
+    mint: &compat::Pubkey,
+    validator: &compat::Pubkey,
+    token_program: &compat::Pubkey,
+) -> compat::Pubkey {
+    let (queue, _queue_bump) = find_transfer_queue(mint, validator);
+    find_associated_token_address_with_bump(&queue, mint, token_program).0
+}
+
 pub fn find_transfer_queue_refill_state(queue: &compat::Pubkey) -> (compat::Pubkey, u8) {
     compat::Pubkey::find_program_address(&[b"queue-refill", queue.as_ref()], &ESPL_TOKEN_PROGRAM_ID)
 }

--- a/rust/tests/spl_test.rs
+++ b/rust/tests/spl_test.rs
@@ -35,8 +35,9 @@ mod tests {
             },
             find_hydra_crank_pda, find_lamports_pda, find_rent_pda, find_shuttle_ata,
             find_shuttle_ephemeral_ata, find_shuttle_wallet_ata, find_stash_pda,
-            find_transfer_queue, find_transfer_queue_refill_state, find_vault_ata, EphemeralAta,
-            EphemeralSplDiscriminator, GlobalVault,
+            find_transfer_queue, find_transfer_queue_ephemeral_ata,
+            find_transfer_queue_refill_state, find_transfer_queue_vault_ata, find_vault_ata,
+            EphemeralAta, EphemeralSplDiscriminator, GlobalVault,
         },
     };
     use magicblock_magic_program_api::Pubkey;
@@ -151,6 +152,16 @@ mod tests {
         let validator = Pubkey::new_unique();
         let (queue, _queue_bump) = find_transfer_queue(&mint, &validator);
         let (queue_permission, _permission_bump) = Permission::find_pda(&queue);
+        let (queue_ephemeral_ata, _queue_eata_bump) =
+            find_transfer_queue_ephemeral_ata(&mint, &validator);
+        let queue_vault_ata = find_transfer_queue_vault_ata(&mint, &validator, &TOKEN_PROGRAM_ID);
+        let delegation_buffer = delegate_buffer_pda_from_delegated_account_and_owner_program(
+            &queue_ephemeral_ata,
+            &ESPL_TOKEN_PROGRAM_ID,
+        );
+        let delegation_record = delegation_record_pda_from_delegated_account(&queue_ephemeral_ata);
+        let delegation_metadata =
+            delegation_metadata_pda_from_delegated_account(&queue_ephemeral_ata);
 
         let instruction = InitializeTransferQueueBuilder {
             payer,
@@ -161,7 +172,7 @@ mod tests {
         .instruction();
 
         assert_eq!(instruction.program_id, ESPL_TOKEN_PROGRAM_ID);
-        assert_eq!(instruction.accounts.len(), 7);
+        assert_eq!(instruction.accounts.len(), 16);
         assert_eq!(instruction.accounts[0].pubkey, payer);
         assert_eq!(instruction.accounts[1].pubkey, queue);
         assert_eq!(instruction.accounts[2].pubkey, queue_permission);
@@ -169,6 +180,15 @@ mod tests {
         assert_eq!(instruction.accounts[4].pubkey, validator);
         assert_eq!(instruction.accounts[5].pubkey, system_program::id());
         assert_eq!(instruction.accounts[6].pubkey, PERMISSION_PROGRAM_ID);
+        assert_eq!(instruction.accounts[7].pubkey, queue_ephemeral_ata);
+        assert_eq!(instruction.accounts[8].pubkey, queue_vault_ata);
+        assert_eq!(instruction.accounts[9].pubkey, TOKEN_PROGRAM_ID);
+        assert_eq!(instruction.accounts[10].pubkey, ASSOCIATED_TOKEN_PROGRAM_ID);
+        assert_eq!(instruction.accounts[11].pubkey, ESPL_TOKEN_PROGRAM_ID);
+        assert_eq!(instruction.accounts[12].pubkey, delegation_buffer);
+        assert_eq!(instruction.accounts[13].pubkey, delegation_record);
+        assert_eq!(instruction.accounts[14].pubkey, delegation_metadata);
+        assert_eq!(instruction.accounts[15].pubkey, DELEGATION_PROGRAM_ID);
         assert_eq!(
             instruction.data[0],
             EphemeralSplDiscriminator::InitializeTransferQueue as u8

--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -27,6 +27,8 @@ import {
   delegateSplWithPrivateTransfer,
   delegateTransferQueueIx,
   deriveEphemeralAta,
+  deriveQueueEphemeralAta,
+  deriveQueueVaultAta,
   deriveLamportsPda,
   deriveTransferQueue,
   deriveRentPda,
@@ -52,6 +54,7 @@ import {
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   HYDRA_PROGRAM_ID,
   PERMISSION_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
 } from "../constants";
 import {
   delegateBufferPdaFromDelegatedAccountAndOwnerProgram,
@@ -1084,6 +1087,11 @@ describe("Exposed Instructions (@solana/kit)", () => {
     });
 
     it("should initialize the destination ATA and vault when requested", async () => {
+      const [queue] = await deriveTransferQueue(mint, validator);
+      const [queueEphemeralAta] = await deriveQueueEphemeralAta(
+        mint,
+        validator,
+      );
       const [vault] = await deriveVault(mint);
       const [vaultEphemeralAta] = await deriveEphemeralAta(vault, mint);
       const [fromEphemeralAta] = await deriveEphemeralAta(from, mint);
@@ -1103,14 +1111,19 @@ describe("Exposed Instructions (@solana/kit)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(6);
-      expect(instructions[2].accounts?.[1].address).toBe(vaultEphemeralAta);
+      expect(instructions).toHaveLength(7);
+      expect(instructions[0].data?.[0]).toBe(1);
+      expect(instructions[1].data?.[0]).toBe(1);
       expect(instructions[2].data?.[0]).toBe(4);
-      expect(instructions[3].data?.[0]).toBe(0);
-      expect(instructions[3].accounts?.[0].address).toBe(fromEphemeralAta);
-      expect(instructions[4].data?.[0]).toBe(4);
-      expect(instructions[4].accounts?.[1].address).toBe(fromEphemeralAta);
-      expect(instructions[5].data?.[0]).toBe(25);
+      expect(instructions[2].accounts?.[1].address).toBe(vaultEphemeralAta);
+      expect(instructions[3].data?.[0]).toBe(12);
+      expect(instructions[3].accounts?.[1].address).toBe(queue);
+      expect(instructions[3].accounts?.[7].address).toBe(queueEphemeralAta);
+      expect(instructions[4].data?.[0]).toBe(0);
+      expect(instructions[4].accounts?.[0].address).toBe(fromEphemeralAta);
+      expect(instructions[5].data?.[0]).toBe(4);
+      expect(instructions[5].accounts?.[1].address).toBe(fromEphemeralAta);
+      expect(instructions[6].data?.[0]).toBe(25);
     });
 
     it("should prepend source ATA creation when initAtasIfMissing is set on base-source transfers", async () => {
@@ -1199,23 +1212,24 @@ describe("Exposed Instructions (@solana/kit)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(1);
-      expect(instructions[0].data?.[0]).toBe(16);
-      expect(instructions[0].accounts).toHaveLength(9);
-      expect(instructions[0].accounts?.[5].address).toBe(to);
-      expect(instructions[0].accounts?.[8].address).toBe(
-        instructions[0].accounts?.[3].address,
+      expect(instructions).toHaveLength(2);
+      expect(instructions[0].data?.[0]).toBe(12);
+      expect(instructions[1].data?.[0]).toBe(16);
+      expect(instructions[1].accounts).toHaveLength(9);
+      expect(instructions[1].accounts?.[5].address).toBe(to);
+      expect(instructions[1].accounts?.[8].address).toBe(
+        instructions[1].accounts?.[3].address,
       );
-      expect(Buffer.from(instructions[0].data ?? []).readBigUInt64LE(1)).toBe(
+      expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(1)).toBe(
         25n,
       );
-      expect(Buffer.from(instructions[0].data ?? []).readBigUInt64LE(9)).toBe(
+      expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(9)).toBe(
         100n,
       );
-      expect(Buffer.from(instructions[0].data ?? []).readBigUInt64LE(17)).toBe(
+      expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(17)).toBe(
         300n,
       );
-      expect(Buffer.from(instructions[0].data ?? []).readUInt32LE(25)).toBe(4);
+      expect(Buffer.from(instructions[1].data ?? []).readUInt32LE(25)).toBe(4);
     });
 
     it("should require validator for private ephemeral-to-base transfers", async () => {
@@ -1529,6 +1543,11 @@ describe("Exposed Instructions (@solana/kit)", () => {
 
     it("should include validator and requested item count in initTransferQueueIx", async () => {
       const [queue] = await deriveTransferQueue(mint, validator);
+      const [queueEphemeralAta] = await deriveQueueEphemeralAta(
+        mint,
+        validator,
+      );
+      const queueVaultAta = await deriveQueueVaultAta(mint, validator);
       const instruction = await initTransferQueueIx(
         mockAddress,
         queue,
@@ -1537,12 +1556,28 @@ describe("Exposed Instructions (@solana/kit)", () => {
         92,
       );
 
-      expect(instruction.accounts).toHaveLength(7);
+      expect(instruction.accounts).toHaveLength(16);
       expect(instruction.accounts?.[2].address).toBe(
         await permissionPdaFromAccount(queue),
       );
       expect(instruction.accounts?.[4].address).toBe(validator);
       expect(instruction.accounts?.[6].address).toBe(PERMISSION_PROGRAM_ID);
+      expect(instruction.accounts?.[7].address).toBe(queueEphemeralAta);
+      expect(instruction.accounts?.[8].address).toBe(queueVaultAta);
+      expect(instruction.accounts?.[9].address).toBe(TOKEN_PROGRAM_ID);
+      expect(instruction.accounts?.[12].address).toBe(
+        await delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+          queueEphemeralAta,
+          EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+        ),
+      );
+      expect(instruction.accounts?.[13].address).toBe(
+        await delegationRecordPdaFromDelegatedAccount(queueEphemeralAta),
+      );
+      expect(instruction.accounts?.[14].address).toBe(
+        await delegationMetadataPdaFromDelegatedAccount(queueEphemeralAta),
+      );
+      expect(instruction.accounts?.[15].address).toBe(DELEGATION_PROGRAM_ID);
       expect(Array.from(instruction.data ?? [])).toEqual([12, 92, 0, 0, 0]);
     });
 

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -35,6 +35,7 @@ import {
 } from "../../pda";
 import {
   depositAndQueueTransferIx,
+  deriveQueueVaultAta,
   deriveTransferQueue,
   initTransferQueueIx,
 } from "./transferQueue";
@@ -1635,10 +1636,14 @@ export async function transferSpl(
           }
 
           const [queue] = await deriveTransferQueue(mint, validator);
-          const [vault] = await deriveVault(mint);
-          const vaultAta = await deriveVaultAta(mint, vault);
+          const vault = queue;
+          const vaultAta = await deriveQueueVaultAta(mint, validator);
+          const setupInstructions = initVaultIfMissing
+            ? [await initTransferQueueIx(payer, queue, mint, validator)]
+            : [];
 
           return [
+            ...setupInstructions,
             depositAndQueueTransferIx(
               queue,
               vault,
@@ -1684,6 +1689,22 @@ export async function transferSpl(
       initVaultAtaIx(payer, vaultAta, vault, mint),
       await delegateIx(payer, vaultEphemeralAta, validator),
     );
+  }
+
+  if (
+    initVaultIfMissing &&
+    opts.visibility === "private" &&
+    opts.fromBalance === "base" &&
+    opts.toBalance === "base"
+  ) {
+    if (validator == null) {
+      throw new Error(
+        "validator is required for private base-to-base transfers",
+      );
+    }
+
+    const [queue] = await deriveTransferQueue(mint, validator);
+    instructions.push(await initTransferQueueIx(payer, queue, mint, validator));
   }
 
   if (opts.fromBalance === "base" && initAtasIfMissing) {

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -2,18 +2,19 @@ import {
   AccountRole,
   Address,
   Instruction,
-  address,
   getAddressEncoder,
   getProgramDerivedAddress,
 } from "@solana/kit";
 import { SYSTEM_PROGRAM_ADDRESS } from "@solana-program/system";
 
 import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
   DELEGATION_PROGRAM_ID,
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   MAGIC_CONTEXT_ID,
   MAGIC_PROGRAM_ID,
   PERMISSION_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
 } from "../../constants";
 import {
   delegateBufferPdaFromDelegatedAccountAndOwnerProgram,
@@ -32,10 +33,6 @@ const QUEUE_SEED = new TextEncoder().encode("queue");
 const QUEUE_REFILL_STATE_SEED = new TextEncoder().encode("queue-refill");
 const RENT_PDA_SEED = new TextEncoder().encode("rent");
 const LAMPORTS_PDA_SEED = new TextEncoder().encode("lamports");
-const TOKEN_PROGRAM_ADDRESS = address(
-  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-);
-
 /**
  * Derive the transfer queue PDA for a mint/validator pair.
  * @param mint - The mint account address
@@ -58,6 +55,37 @@ export async function deriveTransferQueue(
   return [queue, bump];
 }
 
+export async function deriveQueueEphemeralAta(
+  mint: Address,
+  validator: Address,
+): Promise<[Address, number]> {
+  const addressEncoder = getAddressEncoder();
+  const [queue] = await deriveTransferQueue(mint, validator);
+  const [queueEphemeralAta, bump] = await getProgramDerivedAddress({
+    programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    seeds: [addressEncoder.encode(queue), addressEncoder.encode(mint)],
+  });
+  return [queueEphemeralAta, bump];
+}
+
+export async function deriveQueueVaultAta(
+  mint: Address,
+  validator: Address,
+  tokenProgram: Address = TOKEN_PROGRAM_ID,
+): Promise<Address> {
+  const addressEncoder = getAddressEncoder();
+  const [queue] = await deriveTransferQueue(mint, validator);
+  const [ata] = await getProgramDerivedAddress({
+    programAddress: ASSOCIATED_TOKEN_PROGRAM_ID,
+    seeds: [
+      addressEncoder.encode(queue),
+      addressEncoder.encode(tokenProgram),
+      addressEncoder.encode(mint),
+    ],
+  });
+  return ata;
+}
+
 /**
  * Initialize the per-validator transfer queue for a mint.
  * @param payer - The payer account
@@ -73,7 +101,15 @@ export async function initTransferQueueIx(
   mint: Address,
   validator: Address,
   requestedItems?: number,
+  tokenProgram: Address = TOKEN_PROGRAM_ID,
 ): Promise<Instruction> {
+  const [queueEphemeralAta] = await deriveQueueEphemeralAta(mint, validator);
+  const queueVaultAta = await deriveQueueVaultAta(
+    mint,
+    validator,
+    tokenProgram,
+  );
+
   return {
     accounts: [
       { address: payer, role: AccountRole.WRITABLE_SIGNER },
@@ -86,6 +122,29 @@ export async function initTransferQueueIx(
       { address: validator, role: AccountRole.READONLY },
       { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
       { address: PERMISSION_PROGRAM_ID, role: AccountRole.READONLY },
+      { address: queueEphemeralAta, role: AccountRole.WRITABLE },
+      { address: queueVaultAta, role: AccountRole.WRITABLE },
+      { address: tokenProgram, role: AccountRole.READONLY },
+      { address: ASSOCIATED_TOKEN_PROGRAM_ID, role: AccountRole.READONLY },
+      { address: EPHEMERAL_SPL_TOKEN_PROGRAM_ID, role: AccountRole.READONLY },
+      {
+        address: await delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+          queueEphemeralAta,
+          EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+        ),
+        role: AccountRole.WRITABLE,
+      },
+      {
+        address:
+          await delegationRecordPdaFromDelegatedAccount(queueEphemeralAta),
+        role: AccountRole.WRITABLE,
+      },
+      {
+        address:
+          await delegationMetadataPdaFromDelegatedAccount(queueEphemeralAta),
+        role: AccountRole.WRITABLE,
+      },
+      { address: DELEGATION_PROGRAM_ID, role: AccountRole.READONLY },
     ],
     data:
       requestedItems === undefined
@@ -117,7 +176,7 @@ export function allocateTransferQueueIx(queue: Address): Instruction {
 /**
  * Deposit SPL tokens into the vault and queue one or more delayed transfers.
  * @param queue - The transfer queue PDA
- * @param vault - The mint vault PDA
+ * @param vault - The vault authority PDA (global vault or transfer queue)
  * @param mint - The mint account
  * @param source - The sender token account
  * @param vaultAta - The vault token account
@@ -145,6 +204,7 @@ export function depositAndQueueTransferIx(
   split: number = 1,
   reimbursementTokenInfo: Address = source,
   clientRefId?: bigint,
+  tokenProgram: Address = TOKEN_PROGRAM_ID,
 ): Instruction {
   if (!Number.isInteger(split) || split <= 0 || split > 0xffff_ffff) {
     throw new Error("split must fit in u32");
@@ -181,7 +241,7 @@ export function depositAndQueueTransferIx(
       { address: vaultAta, role: AccountRole.WRITABLE },
       { address: destination, role: AccountRole.READONLY },
       { address: owner, role: AccountRole.READONLY_SIGNER },
-      { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+      { address: tokenProgram, role: AccountRole.READONLY },
       { address: reimbursementTokenInfo, role: AccountRole.WRITABLE },
     ],
     data: new Uint8Array(data),

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -25,6 +25,8 @@ import {
   deriveEphemeralAta,
   deriveHydraCrankPda,
   deriveLamportsPda,
+  deriveQueueEphemeralAta,
+  deriveQueueVaultAta,
   deriveStashPda,
   deriveTransferQueue,
   deriveRentPda,
@@ -52,6 +54,7 @@ import {
   MAGIC_PROGRAM_ID,
   MAGIC_CONTEXT_ID,
   PERMISSION_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   TOKEN_2022_PROGRAM_ID,
 } from "../constants";
 import {
@@ -1167,6 +1170,8 @@ describe("Exposed Instructions (web3.js)", () => {
     });
 
     it("should initialize the destination ATA and vault when requested", async () => {
+      const [queue] = deriveTransferQueue(mint, validator);
+      const [queueEphemeralAta] = deriveQueueEphemeralAta(mint, validator);
       const [vault] = deriveVault(mint);
       const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
       const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
@@ -1186,25 +1191,37 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(6);
+      expect(instructions).toHaveLength(7);
+      expect(instructions[0].data[0]).toBe(1);
+      expect(instructions[1].data[0]).toBe(1);
+      expect(instructions[2].data[0]).toBe(4);
       expect(instructions[2].keys[1].pubkey.toBase58()).toBe(
         vaultEphemeralAta.toBase58(),
       );
-      expect(instructions[2].data[0]).toBe(4);
-      expect(instructions[3].data[0]).toBe(0);
-      expect(instructions[3].keys[0].pubkey.toBase58()).toBe(
+      expect(instructions[3].data[0]).toBe(12);
+      expect(instructions[3].keys[1].pubkey.toBase58()).toBe(queue.toBase58());
+      expect(instructions[3].keys[7].pubkey.toBase58()).toBe(
+        queueEphemeralAta.toBase58(),
+      );
+      expect(instructions[4].data[0]).toBe(0);
+      expect(instructions[4].keys[0].pubkey.toBase58()).toBe(
         fromEphemeralAta.toBase58(),
       );
-      expect(instructions[4].data[0]).toBe(4);
-      expect(instructions[4].keys[1].pubkey.toBase58()).toBe(
+      expect(instructions[5].data[0]).toBe(4);
+      expect(instructions[5].keys[1].pubkey.toBase58()).toBe(
         fromEphemeralAta.toBase58(),
       );
-      expect(instructions[5].data[0]).toBe(25);
+      expect(instructions[6].data[0]).toBe(25);
     });
 
     it("should use the token program override when initializing the vault", async () => {
       const [vault] = deriveVault(mint);
       const vaultAta = deriveVaultAta(mint, vault, TOKEN_2022_PROGRAM_ID);
+      const queueVaultAta = deriveQueueVaultAta(
+        mint,
+        validator,
+        TOKEN_2022_PROGRAM_ID,
+      );
 
       const instructions = await transferSpl(from, to, mint, 25n, {
         visibility: "private",
@@ -1221,7 +1238,7 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(6);
+      expect(instructions).toHaveLength(7);
       expect(instructions[0].keys[4].pubkey.toBase58()).toBe(
         vaultAta.toBase58(),
       );
@@ -1234,10 +1251,16 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(instructions[1].keys[5].pubkey.toBase58()).toBe(
         TOKEN_2022_PROGRAM_ID.toBase58(),
       );
-      expect(instructions[5].keys[14].pubkey.toBase58()).toBe(
+      expect(instructions[3].keys[8].pubkey.toBase58()).toBe(
+        queueVaultAta.toBase58(),
+      );
+      expect(instructions[3].keys[9].pubkey.toBase58()).toBe(
         TOKEN_2022_PROGRAM_ID.toBase58(),
       );
-      expect(instructions[5].keys[17].pubkey.toBase58()).toBe(
+      expect(instructions[6].keys[14].pubkey.toBase58()).toBe(
+        TOKEN_2022_PROGRAM_ID.toBase58(),
+      );
+      expect(instructions[6].keys[17].pubkey.toBase58()).toBe(
         vaultAta.toBase58(),
       );
     });
@@ -1330,17 +1353,18 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(1);
-      expect(instructions[0].data[0]).toBe(16);
-      expect(instructions[0].keys).toHaveLength(9);
-      expect(instructions[0].keys[5].pubkey.toBase58()).toBe(to.toBase58());
-      expect(instructions[0].keys[8].pubkey.toBase58()).toBe(
-        instructions[0].keys[3].pubkey.toBase58(),
+      expect(instructions).toHaveLength(2);
+      expect(instructions[0].data[0]).toBe(12);
+      expect(instructions[1].data[0]).toBe(16);
+      expect(instructions[1].keys).toHaveLength(9);
+      expect(instructions[1].keys[5].pubkey.toBase58()).toBe(to.toBase58());
+      expect(instructions[1].keys[8].pubkey.toBase58()).toBe(
+        instructions[1].keys[3].pubkey.toBase58(),
       );
-      expect(Buffer.from(instructions[0].data).readBigUInt64LE(1)).toBe(25n);
-      expect(Buffer.from(instructions[0].data).readBigUInt64LE(9)).toBe(100n);
-      expect(Buffer.from(instructions[0].data).readBigUInt64LE(17)).toBe(300n);
-      expect(Buffer.from(instructions[0].data).readUInt32LE(25)).toBe(4);
+      expect(Buffer.from(instructions[1].data).readBigUInt64LE(1)).toBe(25n);
+      expect(Buffer.from(instructions[1].data).readBigUInt64LE(9)).toBe(100n);
+      expect(Buffer.from(instructions[1].data).readBigUInt64LE(17)).toBe(300n);
+      expect(Buffer.from(instructions[1].data).readUInt32LE(25)).toBe(4);
     });
 
     it("should require validator for private ephemeral-to-base transfers", async () => {
@@ -1624,6 +1648,8 @@ describe("Exposed Instructions (web3.js)", () => {
 
     it("should include validator and requested item count in initTransferQueueIx", () => {
       const [queue] = deriveTransferQueue(mint, validator);
+      const [queueEphemeralAta] = deriveQueueEphemeralAta(mint, validator);
+      const queueVaultAta = deriveQueueVaultAta(mint, validator);
       const instruction = initTransferQueueIx(
         mockPublicKey,
         queue,
@@ -1633,13 +1659,37 @@ describe("Exposed Instructions (web3.js)", () => {
       );
 
       expect(instruction).toBeInstanceOf(TransactionInstruction);
-      expect(instruction.keys).toHaveLength(7);
+      expect(instruction.keys).toHaveLength(16);
       expect(instruction.keys[2].pubkey.toBase58()).toBe(
         permissionPdaFromAccount(queue).toBase58(),
       );
       expect(instruction.keys[4].pubkey.toBase58()).toBe(validator.toBase58());
       expect(instruction.keys[6].pubkey.toBase58()).toBe(
         PERMISSION_PROGRAM_ID.toBase58(),
+      );
+      expect(instruction.keys[7].pubkey.toBase58()).toBe(
+        queueEphemeralAta.toBase58(),
+      );
+      expect(instruction.keys[8].pubkey.toBase58()).toBe(
+        queueVaultAta.toBase58(),
+      );
+      expect(instruction.keys[9].pubkey.toBase58()).toBe(
+        TOKEN_PROGRAM_ID.toBase58(),
+      );
+      expect(instruction.keys[12].pubkey.toBase58()).toBe(
+        delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+          queueEphemeralAta,
+          EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+        ).toBase58(),
+      );
+      expect(instruction.keys[13].pubkey.toBase58()).toBe(
+        delegationRecordPdaFromDelegatedAccount(queueEphemeralAta).toBase58(),
+      );
+      expect(instruction.keys[14].pubkey.toBase58()).toBe(
+        delegationMetadataPdaFromDelegatedAccount(queueEphemeralAta).toBase58(),
+      );
+      expect(instruction.keys[15].pubkey.toBase58()).toBe(
+        DELEGATION_PROGRAM_ID.toBase58(),
       );
       expect(Array.from(instruction.data)).toEqual([12, 92, 0, 0, 0]);
     });

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -22,6 +22,7 @@ import {
 } from "../../pda.js";
 import {
   depositAndQueueTransferIx,
+  deriveQueueVaultAta,
   deriveTransferQueue,
   initTransferQueueIx,
   toTransactionInstruction,
@@ -1704,7 +1705,14 @@ export async function delegateSplWithPrivateTransfer(
   if (initTransferQueueIfMissing) {
     instructions.push(
       toTransactionInstruction(
-        initTransferQueueIx(payer, queue, mint, validator),
+        initTransferQueueIx(
+          payer,
+          queue,
+          mint,
+          validator,
+          undefined,
+          tokenProgram,
+        ),
       ),
     );
   }
@@ -1771,8 +1779,6 @@ export async function transferSpl(
   const exactOut = opts.privateTransfer?.exactOut ?? true;
   const clientRefId = opts.privateTransfer?.clientRefId;
 
-  console.log("opts: ", opts);
-
   const fromAta = getAssociatedTokenAddressSync(
     mint,
     from,
@@ -1792,10 +1798,25 @@ export async function transferSpl(
           }
 
           const [queue] = deriveTransferQueue(mint, validator);
-          const [vault] = deriveVault(mint);
-          const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
+          const vault = queue;
+          const vaultAta = deriveQueueVaultAta(mint, validator, tokenProgram);
+          const setupInstructions = initVaultIfMissing
+            ? [
+                toTransactionInstruction(
+                  initTransferQueueIx(
+                    payer,
+                    queue,
+                    mint,
+                    validator,
+                    undefined,
+                    tokenProgram,
+                  ),
+                ),
+              ]
+            : [];
 
           return [
+            ...setupInstructions,
             toTransactionInstruction(
               depositAndQueueTransferIx(
                 queue,
@@ -1861,6 +1882,34 @@ export async function transferSpl(
       initVaultIx(vault, mint, payer, tokenProgram),
       initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
       delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
+    );
+  }
+
+  if (
+    initVaultIfMissing &&
+    opts.visibility === "private" &&
+    opts.fromBalance === "base" &&
+    opts.toBalance === "base"
+  ) {
+    if (validator == null) {
+      throw new Error(
+        "validator is required for private base-to-base transfers",
+      );
+    }
+
+    const [queue] = deriveTransferQueue(mint, validator);
+
+    instructions.push(
+      toTransactionInstruction(
+        initTransferQueueIx(
+          payer,
+          queue,
+          mint,
+          validator,
+          undefined,
+          tokenProgram,
+        ),
+      ),
     );
   }
 

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -6,6 +6,7 @@ import {
 } from "@solana/web3.js";
 
 import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
   DELEGATION_PROGRAM_ID,
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   MAGIC_CONTEXT_ID,
@@ -67,6 +68,30 @@ export function deriveTransferQueue(
   );
 }
 
+export function deriveQueueEphemeralAta(
+  mint: PublicKey,
+  validator: PublicKey,
+): [PublicKey, number] {
+  const [queue] = deriveTransferQueue(mint, validator);
+  return PublicKey.findProgramAddressSync(
+    [queue.toBuffer(), mint.toBuffer()],
+    EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+  );
+}
+
+export function deriveQueueVaultAta(
+  mint: PublicKey,
+  validator: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
+): PublicKey {
+  const [queue] = deriveTransferQueue(mint, validator);
+  const [ata] = PublicKey.findProgramAddressSync(
+    [queue.toBuffer(), tokenProgram.toBuffer(), mint.toBuffer()],
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+  );
+  return ata;
+}
+
 /**
  * Initialize the per-validator transfer queue for a mint.
  * @param payer - The payer account
@@ -82,7 +107,11 @@ export function initTransferQueueIx(
   mint: PublicKey,
   validator: PublicKey,
   requestedItems?: number,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
+  const [queueEphemeralAta] = deriveQueueEphemeralAta(mint, validator);
+  const queueVaultAta = deriveQueueVaultAta(mint, validator, tokenProgram);
+
   return toTransactionInstruction({
     accounts: [
       { pubkey: payer, isSigner: true, isWritable: true },
@@ -96,6 +125,38 @@ export function initTransferQueueIx(
       { pubkey: validator, isSigner: false, isWritable: false },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       { pubkey: PERMISSION_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: queueEphemeralAta, isSigner: false, isWritable: true },
+      { pubkey: queueVaultAta, isSigner: false, isWritable: true },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
+      {
+        pubkey: ASSOCIATED_TOKEN_PROGRAM_ID,
+        isSigner: false,
+        isWritable: false,
+      },
+      {
+        pubkey: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+        isSigner: false,
+        isWritable: false,
+      },
+      {
+        pubkey: delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+          queueEphemeralAta,
+          EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+        ),
+        isSigner: false,
+        isWritable: true,
+      },
+      {
+        pubkey: delegationRecordPdaFromDelegatedAccount(queueEphemeralAta),
+        isSigner: false,
+        isWritable: true,
+      },
+      {
+        pubkey: delegationMetadataPdaFromDelegatedAccount(queueEphemeralAta),
+        isSigner: false,
+        isWritable: true,
+      },
+      { pubkey: DELEGATION_PROGRAM_ID, isSigner: false, isWritable: false },
     ],
     data:
       requestedItems === undefined
@@ -129,7 +190,7 @@ export function allocateTransferQueueIx(
 /**
  * Deposit SPL tokens into the vault and queue one or more delayed transfers.
  * @param queue - The transfer queue PDA
- * @param vault - The mint vault PDA
+ * @param vault - The vault authority PDA (global vault or transfer queue)
  * @param mint - The mint account
  * @param source - The sender token account
  * @param vaultAta - The vault token account


### PR DESCRIPTION
## Summary
- add transfer-queue ephemeral ATA and vault ATA derivation to the kit and Rust SDKs
- include queue token/delegation accounts when initializing transfer queues
- use the queue vault account for private queued transfers and update coverage to match the new instruction layout