### PR TITLE
Align undelegate eATA SDK helpers

### DIFF
--- a/rust/pinocchio/src/spl/instructions/undelegate_ephemeral_ata.rs
+++ b/rust/pinocchio/src/spl/instructions/undelegate_ephemeral_ata.rs
@@ -30,8 +30,8 @@ impl<'a> UndelegateEphemeralAta<'a> {
         let mut instruction_accounts =
             [const { MaybeUninit::<InstructionAccount>::uninit() }; NUM_ACCOUNTS];
         instruction_accounts[0].write(InstructionAccount::readonly_signer(self.payer.address()));
-        instruction_accounts[1].write(InstructionAccount::writable(self.user_ata.address()));
-        instruction_accounts[2].write(InstructionAccount::readonly(self.eata.address()));
+        instruction_accounts[1].write(InstructionAccount::readonly(self.user_ata.address()));
+        instruction_accounts[2].write(InstructionAccount::writable(self.eata.address()));
         instruction_accounts[3].write(InstructionAccount::writable(self.magic_context.address()));
         instruction_accounts[4].write(InstructionAccount::readonly(self.magic_program.address()));
 

--- a/rust/sdk/src/spl/builders/undelegate_ephemeral_ata.rs
+++ b/rust/sdk/src/spl/builders/undelegate_ephemeral_ata.rs
@@ -21,8 +21,8 @@ impl UndelegateEphemeralAtaBuilder {
             program_id: ESPL_TOKEN_PROGRAM_ID,
             accounts: vec![
                 compat::AccountMeta::new_readonly(self.payer, true),
-                compat::AccountMeta::new(user_ata, false),
-                compat::AccountMeta::new_readonly(eata, false),
+                compat::AccountMeta::new_readonly(user_ata, false),
+                compat::AccountMeta::new(eata, false),
                 compat::AccountMeta::new(MAGIC_CONTEXT_ID, false),
                 compat::AccountMeta::new_readonly(MAGIC_PROGRAM_ID, false),
             ],

--- a/rust/sdk/src/spl/cpi/undelegate_ephemeral_ata.rs
+++ b/rust/sdk/src/spl/cpi/undelegate_ephemeral_ata.rs
@@ -21,8 +21,8 @@ impl<'a> UndelegateEphemeralAta<'a> {
             program_id: ESPL_TOKEN_PROGRAM_ID,
             accounts: vec![
                 compat::AccountMeta::new_readonly(*self.payer.key, true),
-                compat::AccountMeta::new(*self.user_ata.key, false),
-                compat::AccountMeta::new_readonly(*self.eata.key, false),
+                compat::AccountMeta::new_readonly(*self.user_ata.key, false),
+                compat::AccountMeta::new(*self.eata.key, false),
                 compat::AccountMeta::new(*self.magic_context.key, false),
                 compat::AccountMeta::new_readonly(*self.magic_program.key, false),
             ],

--- a/rust/tests/spl_test.rs
+++ b/rust/tests/spl_test.rs
@@ -699,19 +699,19 @@ mod tests {
         assert_eq!(instruction.accounts[0].pubkey, payer);
         assert!(!instruction.accounts[0].is_writable);
         assert!(instruction.accounts[0].is_signer);
-        // user_ata (writable, not signer)
+        // user_ata (readonly, not signer)
         assert_eq!(
             instruction.accounts[1].pubkey,
             get_associated_token_address(&user, &mint)
         );
-        assert!(instruction.accounts[1].is_writable);
+        assert!(!instruction.accounts[1].is_writable);
         assert!(!instruction.accounts[1].is_signer);
-        // eata (readonly, not signer)
+        // eata (writable, not signer)
         assert_eq!(
             instruction.accounts[2].pubkey,
             EphemeralAta::find_pda(&user, &mint).0
         );
-        assert!(!instruction.accounts[2].is_writable);
+        assert!(instruction.accounts[2].is_writable);
         assert!(!instruction.accounts[2].is_signer);
         // MAGIC_CONTEXT_ID (writable, not signer)
         assert_eq!(instruction.accounts[3].pubkey, MAGIC_CONTEXT_ID);

--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -41,6 +41,7 @@ import {
   processPendingTransferQueueRefillIx,
   schedulePrivateTransferIx,
   transferSpl,
+  undelegateEphemeralAtaIx,
   undelegateAndCloseShuttleEphemeralAtaIx,
   withdrawSplIx,
   withdrawSpl,
@@ -1606,6 +1607,52 @@ describe("Exposed Instructions (@solana/kit)", () => {
       );
 
       expect(Array.from(instruction.data ?? [])).toEqual([7]);
+    });
+  });
+
+  describe("undelegateEphemeralAtaIx (Ephemeral SPL Token Program)", () => {
+    it("should serialize the undelegate eATA accounts", () => {
+      const ata = address("11111111111111111111111111111113");
+      const ephemeralAta = address("11111111111111111111111111111114");
+      const instruction = undelegateEphemeralAtaIx(
+        mockAddress,
+        ata,
+        ephemeralAta,
+      );
+
+      expect(instruction.programAddress).toBe(EPHEMERAL_SPL_TOKEN_PROGRAM_ID);
+      expect(instruction.accounts).toHaveLength(5);
+      expect(instruction.accounts?.[0]).toEqual(
+        expect.objectContaining({
+          address: mockAddress,
+          role: AccountRole.READONLY_SIGNER,
+        }),
+      );
+      expect(instruction.accounts?.[1]).toEqual(
+        expect.objectContaining({
+          address: ata,
+          role: AccountRole.READONLY,
+        }),
+      );
+      expect(instruction.accounts?.[2]).toEqual(
+        expect.objectContaining({
+          address: ephemeralAta,
+          role: AccountRole.WRITABLE,
+        }),
+      );
+      expect(instruction.accounts?.[3]).toEqual(
+        expect.objectContaining({
+          address: MAGIC_CONTEXT_ID,
+          role: AccountRole.WRITABLE,
+        }),
+      );
+      expect(instruction.accounts?.[4]).toEqual(
+        expect.objectContaining({
+          address: MAGIC_PROGRAM_ID,
+          role: AccountRole.READONLY,
+        }),
+      );
+      expect(Array.from(instruction.data ?? [])).toEqual([5]);
     });
   });
 

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -547,6 +547,31 @@ export async function delegateIx(
 }
 
 /**
+ * Undelegate ephemeral ATA instruction
+ * @param payer - The payer account
+ * @param ata - The base-chain ATA account
+ * @param ephemeralAta - The ephemeral ATA state account
+ * @returns The undelegate instruction
+ */
+export function undelegateEphemeralAtaIx(
+  payer: Address,
+  ata: Address,
+  ephemeralAta: Address,
+): Instruction {
+  return {
+    accounts: [
+      { address: payer, role: AccountRole.READONLY_SIGNER },
+      { address: ata, role: AccountRole.READONLY },
+      { address: ephemeralAta, role: AccountRole.WRITABLE },
+      { address: MAGIC_CONTEXT_ID, role: AccountRole.WRITABLE },
+      { address: MAGIC_PROGRAM_ID, role: AccountRole.READONLY },
+    ],
+    data: new Uint8Array([5]),
+    programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+  };
+}
+
+/**
  * Initialize shuttle ephemeral ATA + wallet ATA
  * @param payer - The payer account
  * @param shuttleEphemeralAta - The shuttle metadata account

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -41,6 +41,7 @@ import {
   processPendingTransferQueueRefillIx,
   schedulePrivateTransferIx,
   transferSpl,
+  undelegateEphemeralAtaIx,
   undelegateAndCloseShuttleEphemeralAtaIx,
   withdrawSplIx,
   withdrawSpl,
@@ -1595,6 +1596,52 @@ describe("Exposed Instructions (web3.js)", () => {
       );
       expect(instruction.keys[5].isWritable).toBe(true);
       expect(Array.from(instruction.data)).toEqual([14, 3]);
+    });
+  });
+
+  describe("undelegateEphemeralAtaIx (Ephemeral SPL Token Program)", () => {
+    it("should serialize the undelegate eATA accounts", () => {
+      const ata = new PublicKey("11111111111111111111111111111113");
+      const ephemeralAta = new PublicKey("11111111111111111111111111111114");
+      const instruction = undelegateEphemeralAtaIx(
+        mockPublicKey,
+        ata,
+        ephemeralAta,
+      );
+
+      expect(instruction.programId.toBase58()).toBe(
+        EPHEMERAL_SPL_TOKEN_PROGRAM_ID.toBase58(),
+      );
+      expect(instruction.keys).toHaveLength(5);
+      expect(instruction.keys[0]).toEqual(
+        expect.objectContaining({
+          pubkey: mockPublicKey,
+          isSigner: true,
+          isWritable: false,
+        }),
+      );
+      expect(instruction.keys[1]).toEqual(
+        expect.objectContaining({
+          pubkey: ata,
+          isSigner: false,
+          isWritable: false,
+        }),
+      );
+      expect(instruction.keys[2]).toEqual(
+        expect.objectContaining({
+          pubkey: ephemeralAta,
+          isSigner: false,
+          isWritable: true,
+        }),
+      );
+      expect(instruction.keys[3].pubkey.toBase58()).toBe(
+        MAGIC_CONTEXT_ID.toBase58(),
+      );
+      expect(instruction.keys[3].isWritable).toBe(true);
+      expect(instruction.keys[4].pubkey.toBase58()).toBe(
+        MAGIC_PROGRAM_ID.toBase58(),
+      );
+      expect(Array.from(instruction.data)).toEqual([5]);
     });
   });
 

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -605,6 +605,31 @@ export function delegateEphemeralAtaIx(
 }
 
 /**
+ * Undelegate ephemeral ATA instruction
+ * @param payer - The payer account
+ * @param ata - The base-chain ATA account
+ * @param ephemeralAta - The ephemeral ATA state account
+ * @returns The undelegate instruction
+ */
+export function undelegateEphemeralAtaIx(
+  payer: PublicKey,
+  ata: PublicKey,
+  ephemeralAta: PublicKey,
+): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    keys: [
+      { pubkey: payer, isSigner: true, isWritable: false },
+      { pubkey: ata, isSigner: false, isWritable: false },
+      { pubkey: ephemeralAta, isSigner: false, isWritable: true },
+      { pubkey: MAGIC_CONTEXT_ID, isSigner: false, isWritable: true },
+      { pubkey: MAGIC_PROGRAM_ID, isSigner: false, isWritable: false },
+    ],
+    data: Buffer.from([5]),
+  });
+}
+
+/**
  * Initialize shuttle ephemeral ATA + wallet ATA
  * @param payer - The payer account
  * @param shuttleEphemeralAta - The shuttle metadata account


### PR DESCRIPTION
## Summary

- Add the missing `undelegateEphemeralAtaIx` helper to the kit SDK with account layout coverage.
- Cover the web3js helper layout with a formatted test.
- Align Rust SDK and pinocchio undelegate eATA account mutability with the shared helper layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected account permission flags for ephemeral ATA undelegation operations to ensure proper access control.

* **New Features**
  * Added instruction builders for undelegating ephemeral ATAs across SDK implementations.

* **Tests**
  * Added test coverage verifying undelegation instruction construction and account metadata correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->