### PR TITLE
Skip vault eATA delegation in delegateSpl

### DIFF
--- a/rust/sdk/src/spl/builders/deposit_and_queue_transfer.rs
+++ b/rust/sdk/src/spl/builders/deposit_and_queue_transfer.rs
@@ -2,13 +2,14 @@ use core::fmt;
 
 use crate::{
     compat,
-    consts::{ESPL_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID},
-    spl::EphemeralSplDiscriminator,
+    consts::{EPHEMERAL_VAULT_ID, ESPL_TOKEN_PROGRAM_ID, MAGIC_PROGRAM_ID, TOKEN_PROGRAM_ID},
+    spl::{find_transfer_group_receipt, EphemeralSplDiscriminator},
 };
 
 #[derive(Debug)]
 pub enum DepositAndQueueTransferBuilderError {
     InvalidSplit(u32),
+    RandomGroupIdUnavailable(getrandom::Error),
     InvalidDelayRange {
         min_delay_ms: u64,
         max_delay_ms: u64,
@@ -19,6 +20,9 @@ impl fmt::Display for DepositAndQueueTransferBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidSplit(split) => write!(f, "split must be greater than zero, got {split}"),
+            Self::RandomGroupIdUnavailable(err) => {
+                write!(f, "failed to generate transfer group id: {err}")
+            }
             Self::InvalidDelayRange {
                 min_delay_ms,
                 max_delay_ms,
@@ -61,9 +65,11 @@ impl DepositAndQueueTransferBuilder {
             });
         }
 
-        let mut data = Vec::with_capacity(if self.client_ref_id.is_some() { 37 } else { 29 });
+        let group_id = random_transfer_group_id()?;
+        let mut data = Vec::with_capacity(if self.client_ref_id.is_some() { 40 } else { 32 });
         data.push(EphemeralSplDiscriminator::DepositAndQueueTransfer as u8);
         data.extend_from_slice(&self.amount.to_le_bytes());
+        data.extend_from_slice(&group_id.to_le_bytes()[..3]);
         data.extend_from_slice(&self.min_delay_ms.to_le_bytes());
         data.extend_from_slice(&self.max_delay_ms.to_le_bytes());
         data.extend_from_slice(&self.split.to_le_bytes());
@@ -71,6 +77,8 @@ impl DepositAndQueueTransferBuilder {
             data.extend_from_slice(&client_ref_id.to_le_bytes());
         }
         let reimbursement_token_info = self.reimbursement_token_info.unwrap_or(self.source);
+        let (group_receipt, _group_receipt_bump) =
+            find_transfer_group_receipt(&self.queue, &self.owner, group_id);
 
         Ok(compat::Instruction {
             program_id: ESPL_TOKEN_PROGRAM_ID,
@@ -84,8 +92,22 @@ impl DepositAndQueueTransferBuilder {
                 compat::AccountMeta::new_readonly(self.owner, true),
                 compat::AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
                 compat::AccountMeta::new(reimbursement_token_info, false),
+                compat::AccountMeta::new(group_receipt, false),
+                compat::AccountMeta::new(EPHEMERAL_VAULT_ID, false),
+                compat::AccountMeta::new_readonly(MAGIC_PROGRAM_ID, false),
             ],
             data,
         })
     }
+}
+
+fn random_transfer_group_id() -> Result<u32, DepositAndQueueTransferBuilderError> {
+    let mut bytes = [0u8; 3];
+    let mut group_id = 0;
+    while group_id == 0 {
+        getrandom::getrandom(&mut bytes)
+            .map_err(DepositAndQueueTransferBuilderError::RandomGroupIdUnavailable)?;
+        group_id = u32::from(bytes[0]) | (u32::from(bytes[1]) << 8) | (u32::from(bytes[2]) << 16);
+    }
+    Ok(group_id)
 }

--- a/rust/sdk/src/spl/types.rs
+++ b/rust/sdk/src/spl/types.rs
@@ -172,6 +172,23 @@ pub fn find_transfer_queue_refill_state(queue: &compat::Pubkey) -> (compat::Pubk
     compat::Pubkey::find_program_address(&[b"queue-refill", queue.as_ref()], &ESPL_TOKEN_PROGRAM_ID)
 }
 
+pub fn find_transfer_group_receipt(
+    queue: &compat::Pubkey,
+    source: &compat::Pubkey,
+    group_id: u32,
+) -> (compat::Pubkey, u8) {
+    let group_id_bytes = group_id.to_le_bytes();
+    compat::Pubkey::find_program_address(
+        &[
+            b"group-receipt",
+            queue.as_ref(),
+            source.as_ref(),
+            &group_id_bytes,
+        ],
+        &ESPL_TOKEN_PROGRAM_ID,
+    )
+}
+
 pub fn find_hydra_crank_pda(stash_pda: &compat::Pubkey, shuttle_id: u32) -> (compat::Pubkey, u8) {
     compat::Pubkey::find_program_address(
         &[b"crank", &hydra_seed(stash_pda, shuttle_id)],

--- a/rust/sdk/src/spl/types.rs
+++ b/rust/sdk/src/spl/types.rs
@@ -177,13 +177,14 @@ pub fn find_transfer_group_receipt(
     source: &compat::Pubkey,
     group_id: u32,
 ) -> (compat::Pubkey, u8) {
+    assert!(group_id <= 0x00FF_FFFF, "group_id must fit in 24 bits");
     let group_id_bytes = group_id.to_le_bytes();
     compat::Pubkey::find_program_address(
         &[
             b"group-receipt",
             queue.as_ref(),
             source.as_ref(),
-            &group_id_bytes,
+            &group_id_bytes[..3],
         ],
         &ESPL_TOKEN_PROGRAM_ID,
     )
@@ -200,6 +201,41 @@ fn hydra_seed(stash_pda: &compat::Pubkey, shuttle_id: u32) -> [u8; 32] {
     let mut seed = stash_pda.to_bytes();
     seed[..4].copy_from_slice(&shuttle_id.to_le_bytes());
     seed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_transfer_group_receipt_uses_24_bit_group_id_seed() {
+        let queue = compat::Pubkey::new_from_array([1; 32]);
+        let source = compat::Pubkey::new_from_array([2; 32]);
+        let group_id: u32 = 0x00FF_FFFF;
+        let group_id_bytes = group_id.to_le_bytes();
+
+        let receipt = find_transfer_group_receipt(&queue, &source, group_id);
+        let expected = compat::Pubkey::find_program_address(
+            &[
+                b"group-receipt",
+                queue.as_ref(),
+                source.as_ref(),
+                &group_id_bytes[..3],
+            ],
+            &ESPL_TOKEN_PROGRAM_ID,
+        );
+
+        assert_eq!(receipt, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "group_id must fit in 24 bits")]
+    fn test_find_transfer_group_receipt_rejects_non_24_bit_group_id() {
+        let queue = compat::Pubkey::new_from_array([1; 32]);
+        let source = compat::Pubkey::new_from_array([2; 32]);
+
+        find_transfer_group_receipt(&queue, &source, 0x0100_0000);
+    }
 }
 
 pub(crate) fn find_associated_token_address_with_bump(

--- a/rust/tests/spl_test.rs
+++ b/rust/tests/spl_test.rs
@@ -14,8 +14,9 @@ mod tests {
     use ephemeral_rollups_sdk::{
         access_control::structs::Permission,
         consts::{
-            ASSOCIATED_TOKEN_PROGRAM_ID, ESPL_TOKEN_PROGRAM_ID, HYDRA_PROGRAM_ID, MAGIC_CONTEXT_ID,
-            MAGIC_PROGRAM_ID, PERMISSION_PROGRAM_ID, TOKEN_PROGRAM_ID,
+            ASSOCIATED_TOKEN_PROGRAM_ID, EPHEMERAL_VAULT_ID, ESPL_TOKEN_PROGRAM_ID,
+            HYDRA_PROGRAM_ID, MAGIC_CONTEXT_ID, MAGIC_PROGRAM_ID, PERMISSION_PROGRAM_ID,
+            TOKEN_PROGRAM_ID,
         },
         spl::{
             builders::{
@@ -35,7 +36,7 @@ mod tests {
             },
             find_hydra_crank_pda, find_lamports_pda, find_rent_pda, find_shuttle_ata,
             find_shuttle_ephemeral_ata, find_shuttle_wallet_ata, find_stash_pda,
-            find_transfer_queue, find_transfer_queue_ephemeral_ata,
+            find_transfer_group_receipt, find_transfer_queue, find_transfer_queue_ephemeral_ata,
             find_transfer_queue_refill_state, find_transfer_queue_vault_ata, find_vault_ata,
             EphemeralAta, EphemeralSplDiscriminator, GlobalVault,
         },
@@ -238,9 +239,14 @@ mod tests {
         }
         .instruction()
         .unwrap();
+        let group_id = u32::from(instruction.data[9])
+            | (u32::from(instruction.data[10]) << 8)
+            | (u32::from(instruction.data[11]) << 16);
+        let (group_receipt, _group_receipt_bump) =
+            find_transfer_group_receipt(&queue, &owner, group_id);
 
         assert_eq!(instruction.program_id, ESPL_TOKEN_PROGRAM_ID);
-        assert_eq!(instruction.accounts.len(), 9);
+        assert_eq!(instruction.accounts.len(), 12);
         assert_eq!(instruction.accounts[0].pubkey, queue);
         assert_eq!(instruction.accounts[1].pubkey, vault);
         assert_eq!(instruction.accounts[2].pubkey, mint);
@@ -250,6 +256,9 @@ mod tests {
         assert_eq!(instruction.accounts[6].pubkey, owner);
         assert_eq!(instruction.accounts[7].pubkey, TOKEN_PROGRAM_ID);
         assert_eq!(instruction.accounts[8].pubkey, source);
+        assert_eq!(instruction.accounts[9].pubkey, group_receipt);
+        assert_eq!(instruction.accounts[10].pubkey, EPHEMERAL_VAULT_ID);
+        assert_eq!(instruction.accounts[11].pubkey, MAGIC_PROGRAM_ID);
         assert_eq!(
             instruction.data[0],
             EphemeralSplDiscriminator::DepositAndQueueTransfer as u8
@@ -258,16 +267,17 @@ mod tests {
             u64::from_le_bytes(instruction.data[1..9].try_into().unwrap()),
             25
         );
+        assert_ne!(group_id, 0);
         assert_eq!(
-            u64::from_le_bytes(instruction.data[9..17].try_into().unwrap()),
+            u64::from_le_bytes(instruction.data[12..20].try_into().unwrap()),
             100
         );
         assert_eq!(
-            u64::from_le_bytes(instruction.data[17..25].try_into().unwrap()),
+            u64::from_le_bytes(instruction.data[20..28].try_into().unwrap()),
             300
         );
         assert_eq!(
-            u32::from_le_bytes(instruction.data[25..29].try_into().unwrap()),
+            u32::from_le_bytes(instruction.data[28..32].try_into().unwrap()),
             4
         );
     }
@@ -319,9 +329,15 @@ mod tests {
         .instruction()
         .unwrap();
 
-        assert_eq!(instruction.data.len(), 37);
+        assert_eq!(instruction.data.len(), 40);
+        assert_ne!(
+            u32::from(instruction.data[9])
+                | (u32::from(instruction.data[10]) << 8)
+                | (u32::from(instruction.data[11]) << 16),
+            0
+        );
         assert_eq!(
-            u64::from_le_bytes(instruction.data[29..37].try_into().unwrap()),
+            u64::from_le_bytes(instruction.data[32..40].try_into().unwrap()),
             client_ref_id
         );
     }

--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -786,7 +786,7 @@ describe("Exposed Instructions (@solana/kit)", () => {
     const mint = address("11111111111111111111111111111114");
     const validator = address("11111111111111111111111111111115");
 
-    it("should delegate the vault eata when initializing the vault in legacy flow", async () => {
+    it("should not delegate the vault eata when initializing the vault in legacy flow", async () => {
       const [vault] = await deriveVault(mint);
       const [vaultEphemeralAta] = await deriveEphemeralAta(vault, mint);
 
@@ -797,14 +797,16 @@ describe("Exposed Instructions (@solana/kit)", () => {
         idempotent: false,
       });
 
-      expect(instructions[3].accounts?.[1].address).toBe(vaultEphemeralAta);
-      expect(instructions[3].data?.[0]).toBe(4);
-      expect(Array.from(instructions[3].data?.subarray(1) ?? [])).toEqual(
-        Array.from(addressEncoder.encode(validator)),
-      );
+      expect(
+        instructions.find(
+          (ix) =>
+            ix.data?.[0] === 4 &&
+            ix.accounts?.[1].address === vaultEphemeralAta,
+        ),
+      ).toBeUndefined();
     });
 
-    it("should delegate the vault eata when initializing the vault in idempotent flow", async () => {
+    it("should not delegate the vault eata when initializing the vault in idempotent flow", async () => {
       const [vault] = await deriveVault(mint);
       const [vaultEphemeralAta] = await deriveEphemeralAta(vault, mint);
 
@@ -814,11 +816,13 @@ describe("Exposed Instructions (@solana/kit)", () => {
         shuttleId: 7,
       });
 
-      expect(instructions[2].accounts?.[1].address).toBe(vaultEphemeralAta);
-      expect(instructions[2].data?.[0]).toBe(4);
-      expect(Array.from(instructions[2].data?.subarray(1) ?? [])).toEqual(
-        Array.from(addressEncoder.encode(validator)),
-      );
+      expect(
+        instructions.find(
+          (ix) =>
+            ix.data?.[0] === 4 &&
+            ix.accounts?.[1].address === vaultEphemeralAta,
+        ),
+      ).toBeUndefined();
     });
 
     it("should use setup_and_delegate_shuttle_with_merge across the idempotent shuttle flow", async () => {

--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -27,6 +27,7 @@ import {
   delegateSplWithPrivateTransfer,
   delegateTransferQueueIx,
   deriveEphemeralAta,
+  deriveGroupReceipt,
   deriveQueueEphemeralAta,
   deriveQueueVaultAta,
   deriveLamportsPda,
@@ -51,6 +52,7 @@ import {
   DELEGATION_PROGRAM_ID,
   MAGIC_PROGRAM_ID,
   MAGIC_CONTEXT_ID,
+  EPHEMERAL_VAULT_ID,
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   HYDRA_PROGRAM_ID,
   PERMISSION_PROGRAM_ID,
@@ -934,6 +936,33 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(suffixField).toHaveLength(68);
       expect(endOffset).toBe(data.length);
     });
+
+    it("should not delegate the vault eata when initializing the vault", async () => {
+      const [vault] = await deriveVault(mint);
+      const [vaultEphemeralAta] = await deriveEphemeralAta(vault, mint);
+
+      const instructions = await delegateSplWithPrivateTransfer(
+        owner,
+        mint,
+        1n,
+        {
+          validator,
+          shuttleId: 7,
+          initVaultIfMissing: true,
+          minDelayMs: 100n,
+          maxDelayMs: 300n,
+          split: 4,
+        },
+      );
+
+      expect(
+        instructions.find(
+          (ix) =>
+            ix.data?.[0] === 4 &&
+            ix.accounts?.[1].address === vaultEphemeralAta,
+        ),
+      ).toBeUndefined();
+    });
   });
 
   describe("withdrawSpl (Ephemeral SPL Token Program)", () => {
@@ -1096,8 +1125,6 @@ describe("Exposed Instructions (@solana/kit)", () => {
         mint,
         validator,
       );
-      const [vault] = await deriveVault(mint);
-      const [vaultEphemeralAta] = await deriveEphemeralAta(vault, mint);
       const [fromEphemeralAta] = await deriveEphemeralAta(from, mint);
 
       const instructions = await transferSpl(from, to, mint, 25n, {
@@ -1115,19 +1142,17 @@ describe("Exposed Instructions (@solana/kit)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(7);
+      expect(instructions).toHaveLength(6);
       expect(instructions[0].data?.[0]).toBe(1);
       expect(instructions[1].data?.[0]).toBe(1);
-      expect(instructions[2].data?.[0]).toBe(4);
-      expect(instructions[2].accounts?.[1].address).toBe(vaultEphemeralAta);
-      expect(instructions[3].data?.[0]).toBe(12);
-      expect(instructions[3].accounts?.[1].address).toBe(queue);
-      expect(instructions[3].accounts?.[7].address).toBe(queueEphemeralAta);
-      expect(instructions[4].data?.[0]).toBe(0);
-      expect(instructions[4].accounts?.[0].address).toBe(fromEphemeralAta);
-      expect(instructions[5].data?.[0]).toBe(4);
-      expect(instructions[5].accounts?.[1].address).toBe(fromEphemeralAta);
-      expect(instructions[6].data?.[0]).toBe(25);
+      expect(instructions[2].data?.[0]).toBe(12);
+      expect(instructions[2].accounts?.[1].address).toBe(queue);
+      expect(instructions[2].accounts?.[7].address).toBe(queueEphemeralAta);
+      expect(instructions[3].data?.[0]).toBe(0);
+      expect(instructions[3].accounts?.[0].address).toBe(fromEphemeralAta);
+      expect(instructions[4].data?.[0]).toBe(4);
+      expect(instructions[4].accounts?.[1].address).toBe(fromEphemeralAta);
+      expect(instructions[5].data?.[0]).toBe(25);
     });
 
     it("should prepend source ATA creation when initAtasIfMissing is set on base-source transfers", async () => {
@@ -1159,6 +1184,30 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(Buffer.from(instructions[0].data ?? []).readBigUInt64LE(5)).toBe(
         25n,
       );
+    });
+
+    it("should not delegate the vault eata for private base-to-ephemeral vault setup", async () => {
+      const [vault] = await deriveVault(mint);
+      const [vaultEphemeralAta] = await deriveEphemeralAta(vault, mint);
+
+      const instructions = await transferSpl(from, to, mint, 25n, {
+        visibility: "private",
+        fromBalance: "base",
+        toBalance: "ephemeral",
+        validator,
+        shuttleId: 7,
+        initVaultIfMissing: true,
+      });
+
+      expect(instructions).toHaveLength(3);
+      expect(
+        instructions.find(
+          (ix) =>
+            ix.data?.[0] === 4 &&
+            ix.accounts?.[1].address === vaultEphemeralAta,
+        ),
+      ).toBeUndefined();
+      expect(instructions[2].data?.[0]).toBe(24);
     });
 
     it("should initialize and delegate the receiver eata for private base-to-ephemeral transfers when requested", async () => {
@@ -1219,21 +1268,26 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(instructions).toHaveLength(2);
       expect(instructions[0].data?.[0]).toBe(12);
       expect(instructions[1].data?.[0]).toBe(16);
-      expect(instructions[1].accounts).toHaveLength(9);
+      expect(instructions[1].accounts).toHaveLength(12);
       expect(instructions[1].accounts?.[5].address).toBe(to);
       expect(instructions[1].accounts?.[8].address).toBe(
         instructions[1].accounts?.[3].address,
       );
+      expect(instructions[1].accounts?.[10].address).toBe(EPHEMERAL_VAULT_ID);
+      expect(instructions[1].accounts?.[11].address).toBe(MAGIC_PROGRAM_ID);
       expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(1)).toBe(
         25n,
       );
-      expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(9)).toBe(
+      expect(Buffer.from(instructions[1].data ?? []).readUIntLE(9, 3)).not.toBe(
+        0,
+      );
+      expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(12)).toBe(
         100n,
       );
-      expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(17)).toBe(
+      expect(Buffer.from(instructions[1].data ?? []).readBigUInt64LE(20)).toBe(
         300n,
       );
-      expect(Buffer.from(instructions[1].data ?? []).readUInt32LE(25)).toBe(4);
+      expect(Buffer.from(instructions[1].data ?? []).readUInt32LE(28)).toBe(4);
     });
 
     it("should require validator for private ephemeral-to-base transfers", async () => {
@@ -1391,8 +1445,8 @@ describe("Exposed Instructions (@solana/kit)", () => {
     const vaultAta = address("11111111111111111111111111111116");
     const destination = address("11111111111111111111111111111117");
 
-    it("should serialize min/max delay ms and split", () => {
-      const instruction = depositAndQueueTransferIx(
+    it("should serialize min/max delay ms and split", async () => {
+      const instruction = await depositAndQueueTransferIx(
         queue,
         vault,
         mint,
@@ -1405,33 +1459,39 @@ describe("Exposed Instructions (@solana/kit)", () => {
         300n,
         4,
       );
+      const groupId = Buffer.from(instruction.data ?? []).readUIntLE(9, 3);
+      const [groupReceipt] = await deriveGroupReceipt(
+        queue,
+        mockAddress,
+        groupId,
+      );
 
-      expect(instruction.accounts).toHaveLength(9);
+      expect(instruction.accounts).toHaveLength(12);
+      expect(groupId).not.toBe(0);
       expect(instruction.accounts?.[8].address).toBe(source);
       expect(instruction.accounts?.[8].role).toBe(AccountRole.WRITABLE);
-      expect(Array.from(instruction.data ?? [])).toEqual([
-        16,
-        ...Array.from(
-          Buffer.from(
-            [25n, 100n, 300n].flatMap((value) => {
-              const out = Buffer.alloc(8);
-              out.writeBigUInt64LE(value);
-              return Array.from(out);
-            }),
-          ),
-        ),
-        4,
-        0,
-        0,
-        0,
-      ]);
+      expect(instruction.accounts?.[9].address).toBe(groupReceipt);
+      expect(instruction.accounts?.[9].role).toBe(AccountRole.WRITABLE);
+      expect(instruction.accounts?.[10].address).toBe(EPHEMERAL_VAULT_ID);
+      expect(instruction.accounts?.[10].role).toBe(AccountRole.WRITABLE);
+      expect(instruction.accounts?.[11].address).toBe(MAGIC_PROGRAM_ID);
+      expect(instruction.accounts?.[11].role).toBe(AccountRole.READONLY);
+      expect(instruction.data?.[0]).toBe(16);
+      expect(Buffer.from(instruction.data ?? []).readBigUInt64LE(1)).toBe(25n);
+      expect(Buffer.from(instruction.data ?? []).readBigUInt64LE(12)).toBe(
+        100n,
+      );
+      expect(Buffer.from(instruction.data ?? []).readBigUInt64LE(20)).toBe(
+        300n,
+      );
+      expect(Buffer.from(instruction.data ?? []).readUInt32LE(28)).toBe(4);
     });
 
-    it("should allow overriding the reimbursement token account", () => {
+    it("should allow overriding the reimbursement token account", async () => {
       const reimbursementTokenInfo = address(
         "11111111111111111111111111111118",
       );
-      const instruction = depositAndQueueTransferIx(
+      const instruction = await depositAndQueueTransferIx(
         queue,
         vault,
         mint,
@@ -1449,8 +1509,8 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(instruction.accounts?.[8].address).toBe(reimbursementTokenInfo);
     });
 
-    it("should append clientRefId when provided", () => {
-      const instruction = depositAndQueueTransferIx(
+    it("should append clientRefId when provided", async () => {
+      const instruction = await depositAndQueueTransferIx(
         queue,
         vault,
         mint,
@@ -1466,29 +1526,18 @@ describe("Exposed Instructions (@solana/kit)", () => {
         42n,
       );
 
-      expect(Array.from(instruction.data ?? [])).toEqual([
-        16,
-        ...Array.from(
-          Buffer.from(
-            [25n, 100n, 300n].flatMap((value) => {
-              const out = Buffer.alloc(8);
-              out.writeBigUInt64LE(value);
-              return Array.from(out);
-            }),
-          ),
-        ),
-        4,
-        0,
-        0,
-        0,
-        ...Array.from(
-          (() => {
-            const out = Buffer.alloc(8);
-            out.writeBigUInt64LE(42n);
-            return out;
-          })(),
-        ),
-      ]);
+      expect(instruction.data).toHaveLength(40);
+      expect(instruction.data?.[0]).toBe(16);
+      expect(Buffer.from(instruction.data ?? []).readBigUInt64LE(1)).toBe(25n);
+      expect(Buffer.from(instruction.data ?? []).readUIntLE(9, 3)).not.toBe(0);
+      expect(Buffer.from(instruction.data ?? []).readBigUInt64LE(12)).toBe(
+        100n,
+      );
+      expect(Buffer.from(instruction.data ?? []).readBigUInt64LE(20)).toBe(
+        300n,
+      );
+      expect(Buffer.from(instruction.data ?? []).readUInt32LE(28)).toBe(4);
+      expect(Buffer.from(instruction.data ?? []).readBigUInt64LE(32)).toBe(42n);
     });
   });
 

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1379,7 +1379,6 @@ async function buildDelegateSplInstructions(
     instructions.push(
       initVaultIx(vault, mint, payer, vaultEphemeralAta, vaultAta),
       initVaultAtaIx(payer, vaultAta, vault, mint),
-      await delegateIx(payer, vaultEphemeralAta, validator),
     );
   }
 
@@ -1442,7 +1441,6 @@ async function buildIdempotentDelegateSplInstructions(
     instructions.push(
       initVaultIx(vault, mint, payer, vaultEphemeralAta, vaultAta),
       initVaultAtaIx(payer, vaultAta, vault, mint),
-      await delegateIx(payer, vaultEphemeralAta, validator),
     );
   }
 

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1562,7 +1562,6 @@ export async function delegateSplWithPrivateTransfer(
     instructions.push(
       initVaultIx(vault, mint, payer, vaultEphemeralAta, vaultAta),
       initVaultAtaIx(payer, vaultAta, vault, mint),
-      await delegateIx(payer, vaultEphemeralAta, validator),
     );
   }
 
@@ -1642,7 +1641,7 @@ export async function transferSpl(
 
           return [
             ...setupInstructions,
-            depositAndQueueTransferIx(
+            await depositAndQueueTransferIx(
               queue,
               vault,
               mint,
@@ -1685,7 +1684,6 @@ export async function transferSpl(
     instructions.push(
       initVaultIx(vault, mint, payer, vaultEphemeralAta, vaultAta),
       initVaultAtaIx(payer, vaultAta, vault, mint),
-      await delegateIx(payer, vaultEphemeralAta, validator),
     );
   }
 

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -98,7 +98,7 @@ export async function deriveGroupReceipt(
   }
 
   const addressEncoder = getAddressEncoder();
-  const groupIdBytes = new Uint8Array(u32le(groupId));
+  const groupIdBytes = new Uint8Array(u32le(groupId).slice(0, 3));
   const [groupReceipt, bump] = await getProgramDerivedAddress({
     programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
     seeds: [

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -10,6 +10,7 @@ import { SYSTEM_PROGRAM_ADDRESS } from "@solana-program/system";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   DELEGATION_PROGRAM_ID,
+  EPHEMERAL_VAULT_ID,
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   MAGIC_CONTEXT_ID,
   MAGIC_PROGRAM_ID,
@@ -31,6 +32,7 @@ const ALLOCATE_TRANSFER_QUEUE_DISCRIMINATOR = 27;
 const PROCESS_PENDING_TRANSFER_QUEUE_REFILL_DISCRIMINATOR = 28;
 const QUEUE_SEED = new TextEncoder().encode("queue");
 const QUEUE_REFILL_STATE_SEED = new TextEncoder().encode("queue-refill");
+const GROUP_RECEIPT_SEED = new TextEncoder().encode("group-receipt");
 const RENT_PDA_SEED = new TextEncoder().encode("rent");
 const LAMPORTS_PDA_SEED = new TextEncoder().encode("lamports");
 /**
@@ -84,6 +86,46 @@ export async function deriveQueueVaultAta(
     ],
   });
   return ata;
+}
+
+export async function deriveGroupReceipt(
+  queue: Address,
+  source: Address,
+  groupId: number,
+): Promise<[Address, number]> {
+  if (!Number.isInteger(groupId) || groupId <= 0 || groupId > 0x00ff_ffff) {
+    throw new Error("groupId must be an integer between 1 and 16777215");
+  }
+
+  const addressEncoder = getAddressEncoder();
+  const groupIdBytes = new Uint8Array(u32le(groupId));
+  const [groupReceipt, bump] = await getProgramDerivedAddress({
+    programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    seeds: [
+      GROUP_RECEIPT_SEED,
+      addressEncoder.encode(queue),
+      addressEncoder.encode(source),
+      groupIdBytes,
+    ],
+  });
+  return [groupReceipt, bump];
+}
+
+function randomTransferGroupId(): number {
+  const cryptoObj = (globalThis as any)?.crypto;
+  let groupId = 0;
+
+  while (groupId === 0) {
+    if (cryptoObj?.getRandomValues !== undefined) {
+      const bytes = new Uint8Array(3);
+      cryptoObj.getRandomValues(bytes);
+      groupId = bytes[0] | (bytes[1] << 8) | (bytes[2] << 16);
+    } else {
+      groupId = Math.floor(Math.random() * 0x0100_0000);
+    }
+  }
+
+  return groupId;
 }
 
 /**
@@ -190,7 +232,7 @@ export function allocateTransferQueueIx(queue: Address): Instruction {
  * @param clientRefId - Optional client-provided reference ID attached to each queued split
  * @returns The deposit-and-queue-transfer instruction
  */
-export function depositAndQueueTransferIx(
+export async function depositAndQueueTransferIx(
   queue: Address,
   vault: Address,
   mint: Address,
@@ -205,7 +247,7 @@ export function depositAndQueueTransferIx(
   reimbursementTokenInfo: Address = source,
   clientRefId?: bigint,
   tokenProgram: Address = TOKEN_PROGRAM_ID,
-): Instruction {
+): Promise<Instruction> {
   if (!Number.isInteger(split) || split <= 0 || split > 0xffff_ffff) {
     throw new Error("split must fit in u32");
   }
@@ -221,9 +263,15 @@ export function depositAndQueueTransferIx(
     throw new Error("maxDelayMs must be greater than or equal to minDelayMs");
   }
 
+  const groupId = randomTransferGroupId();
+  const groupIdBytes = u32le(groupId);
+  const [groupReceipt] = await deriveGroupReceipt(queue, owner, groupId);
   const data = [
     DEPOSIT_AND_QUEUE_TRANSFER_DISCRIMINATOR,
     ...u64le(amount),
+    groupIdBytes[0],
+    groupIdBytes[1],
+    groupIdBytes[2],
     ...u64le(minDelayMs),
     ...u64le(maxDelayMs),
     ...u32le(split),
@@ -243,6 +291,9 @@ export function depositAndQueueTransferIx(
       { address: owner, role: AccountRole.READONLY_SIGNER },
       { address: tokenProgram, role: AccountRole.READONLY },
       { address: reimbursementTokenInfo, role: AccountRole.WRITABLE },
+      { address: groupReceipt, role: AccountRole.WRITABLE },
+      { address: EPHEMERAL_VAULT_ID, role: AccountRole.WRITABLE },
+      { address: MAGIC_PROGRAM_ID, role: AccountRole.READONLY },
     ],
     data: new Uint8Array(data),
     programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -25,6 +25,7 @@ import {
   deriveEphemeralAta,
   deriveHydraCrankPda,
   deriveLamportsPda,
+  deriveGroupReceipt,
   deriveQueueEphemeralAta,
   deriveQueueVaultAta,
   deriveStashPda,
@@ -49,6 +50,7 @@ import {
 } from "../instructions/ephemeral-spl-token-program";
 import {
   DELEGATION_PROGRAM_ID,
+  EPHEMERAL_VAULT_ID,
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   HYDRA_PROGRAM_ID,
   MAGIC_PROGRAM_ID,
@@ -992,6 +994,32 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(suffixField).toHaveLength(68);
       expect(endOffset).toBe(data.length);
     });
+
+    it("should not delegate the vault eata when initializing the vault", async () => {
+      const [vault] = deriveVault(mint);
+      const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
+
+      const instructions = await delegateSplWithPrivateTransfer(
+        owner,
+        mint,
+        1n,
+        {
+          validator,
+          shuttleId: 7,
+          initVaultIfMissing: true,
+          minDelayMs: 100n,
+          maxDelayMs: 300n,
+          split: 4,
+        },
+      );
+
+      expect(
+        instructions.find(
+          (ix) =>
+            ix.data[0] === 4 && ix.keys[1]?.pubkey.equals(vaultEphemeralAta),
+        ),
+      ).toBeUndefined();
+    });
   });
 
   describe("withdrawSpl (Ephemeral SPL Token Program)", () => {
@@ -1166,8 +1194,6 @@ describe("Exposed Instructions (web3.js)", () => {
     it("should initialize the destination ATA and vault when requested", async () => {
       const [queue] = deriveTransferQueue(mint, validator);
       const [queueEphemeralAta] = deriveQueueEphemeralAta(mint, validator);
-      const [vault] = deriveVault(mint);
-      const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
       const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
 
       const instructions = await transferSpl(from, to, mint, 25n, {
@@ -1185,27 +1211,23 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(7);
+      expect(instructions).toHaveLength(6);
       expect(instructions[0].data[0]).toBe(1);
       expect(instructions[1].data[0]).toBe(1);
-      expect(instructions[2].data[0]).toBe(4);
-      expect(instructions[2].keys[1].pubkey.toBase58()).toBe(
-        vaultEphemeralAta.toBase58(),
-      );
-      expect(instructions[3].data[0]).toBe(12);
-      expect(instructions[3].keys[1].pubkey.toBase58()).toBe(queue.toBase58());
-      expect(instructions[3].keys[7].pubkey.toBase58()).toBe(
+      expect(instructions[2].data[0]).toBe(12);
+      expect(instructions[2].keys[1].pubkey.toBase58()).toBe(queue.toBase58());
+      expect(instructions[2].keys[7].pubkey.toBase58()).toBe(
         queueEphemeralAta.toBase58(),
       );
-      expect(instructions[4].data[0]).toBe(0);
-      expect(instructions[4].keys[0].pubkey.toBase58()).toBe(
+      expect(instructions[3].data[0]).toBe(0);
+      expect(instructions[3].keys[0].pubkey.toBase58()).toBe(
         fromEphemeralAta.toBase58(),
       );
-      expect(instructions[5].data[0]).toBe(4);
-      expect(instructions[5].keys[1].pubkey.toBase58()).toBe(
+      expect(instructions[4].data[0]).toBe(4);
+      expect(instructions[4].keys[1].pubkey.toBase58()).toBe(
         fromEphemeralAta.toBase58(),
       );
-      expect(instructions[6].data[0]).toBe(25);
+      expect(instructions[5].data[0]).toBe(25);
     });
 
     it("should use the token program override when initializing the vault", async () => {
@@ -1232,7 +1254,7 @@ describe("Exposed Instructions (web3.js)", () => {
         },
       });
 
-      expect(instructions).toHaveLength(7);
+      expect(instructions).toHaveLength(6);
       expect(instructions[0].keys[4].pubkey.toBase58()).toBe(
         vaultAta.toBase58(),
       );
@@ -1245,16 +1267,16 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(instructions[1].keys[5].pubkey.toBase58()).toBe(
         TOKEN_2022_PROGRAM_ID.toBase58(),
       );
-      expect(instructions[3].keys[8].pubkey.toBase58()).toBe(
+      expect(instructions[2].keys[8].pubkey.toBase58()).toBe(
         queueVaultAta.toBase58(),
       );
-      expect(instructions[3].keys[9].pubkey.toBase58()).toBe(
+      expect(instructions[2].keys[9].pubkey.toBase58()).toBe(
         TOKEN_2022_PROGRAM_ID.toBase58(),
       );
-      expect(instructions[6].keys[14].pubkey.toBase58()).toBe(
+      expect(instructions[5].keys[14].pubkey.toBase58()).toBe(
         TOKEN_2022_PROGRAM_ID.toBase58(),
       );
-      expect(instructions[6].keys[17].pubkey.toBase58()).toBe(
+      expect(instructions[5].keys[17].pubkey.toBase58()).toBe(
         vaultAta.toBase58(),
       );
     });
@@ -1286,6 +1308,29 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(instructions[0].data[0]).toBe(24);
       expect(instructions[0].keys).toHaveLength(19);
       expect(Buffer.from(instructions[0].data).readBigUInt64LE(5)).toBe(25n);
+    });
+
+    it("should not delegate the vault eata for private base-to-ephemeral vault setup", async () => {
+      const [vault] = deriveVault(mint);
+      const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
+
+      const instructions = await transferSpl(from, to, mint, 25n, {
+        visibility: "private",
+        fromBalance: "base",
+        toBalance: "ephemeral",
+        validator,
+        shuttleId: 7,
+        initVaultIfMissing: true,
+      });
+
+      expect(instructions).toHaveLength(3);
+      expect(
+        instructions.find(
+          (ix) =>
+            ix.data[0] === 4 && ix.keys[1]?.pubkey.equals(vaultEphemeralAta),
+        ),
+      ).toBeUndefined();
+      expect(instructions[2].data[0]).toBe(24);
     });
 
     it("should initialize and delegate the receiver eata for private base-to-ephemeral transfers when requested", async () => {
@@ -1350,15 +1395,22 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(instructions).toHaveLength(2);
       expect(instructions[0].data[0]).toBe(12);
       expect(instructions[1].data[0]).toBe(16);
-      expect(instructions[1].keys).toHaveLength(9);
+      expect(instructions[1].keys).toHaveLength(12);
       expect(instructions[1].keys[5].pubkey.toBase58()).toBe(to.toBase58());
       expect(instructions[1].keys[8].pubkey.toBase58()).toBe(
         instructions[1].keys[3].pubkey.toBase58(),
       );
+      expect(instructions[1].keys[10].pubkey.toBase58()).toBe(
+        EPHEMERAL_VAULT_ID.toBase58(),
+      );
+      expect(instructions[1].keys[11].pubkey.toBase58()).toBe(
+        MAGIC_PROGRAM_ID.toBase58(),
+      );
       expect(Buffer.from(instructions[1].data).readBigUInt64LE(1)).toBe(25n);
-      expect(Buffer.from(instructions[1].data).readBigUInt64LE(9)).toBe(100n);
-      expect(Buffer.from(instructions[1].data).readBigUInt64LE(17)).toBe(300n);
-      expect(Buffer.from(instructions[1].data).readUInt32LE(25)).toBe(4);
+      expect(Buffer.from(instructions[1].data).readUIntLE(9, 3)).not.toBe(0);
+      expect(Buffer.from(instructions[1].data).readBigUInt64LE(12)).toBe(100n);
+      expect(Buffer.from(instructions[1].data).readBigUInt64LE(20)).toBe(300n);
+      expect(Buffer.from(instructions[1].data).readUInt32LE(28)).toBe(4);
     });
 
     it("should require validator for private ephemeral-to-base transfers", async () => {
@@ -1489,28 +1541,35 @@ describe("Exposed Instructions (web3.js)", () => {
         100n,
         300n,
         4,
+        source,
+        undefined,
+        TOKEN_PROGRAM_ID,
       );
+      const groupId = Buffer.from(instruction.data).readUIntLE(9, 3);
+      const [groupReceipt] = deriveGroupReceipt(queue, mockPublicKey, groupId);
 
       expect(instruction).toBeInstanceOf(TransactionInstruction);
-      expect(instruction.keys).toHaveLength(9);
+      expect(instruction.keys).toHaveLength(12);
+      expect(groupId).not.toBe(0);
       expect(instruction.keys[8].pubkey.toBase58()).toBe(source.toBase58());
       expect(instruction.keys[8].isWritable).toBe(true);
-      expect(Array.from(instruction.data)).toEqual([
-        16,
-        ...Array.from(
-          Buffer.from(
-            [25n, 100n, 300n].flatMap((value) => {
-              const out = Buffer.alloc(8);
-              out.writeBigUInt64LE(value);
-              return Array.from(out);
-            }),
-          ),
-        ),
-        4,
-        0,
-        0,
-        0,
-      ]);
+      expect(instruction.keys[9].pubkey.toBase58()).toBe(
+        groupReceipt.toBase58(),
+      );
+      expect(instruction.keys[9].isWritable).toBe(true);
+      expect(instruction.keys[10].pubkey.toBase58()).toBe(
+        EPHEMERAL_VAULT_ID.toBase58(),
+      );
+      expect(instruction.keys[10].isWritable).toBe(true);
+      expect(instruction.keys[11].pubkey.toBase58()).toBe(
+        MAGIC_PROGRAM_ID.toBase58(),
+      );
+      expect(instruction.keys[11].isWritable).toBe(false);
+      expect(instruction.data[0]).toBe(16);
+      expect(Buffer.from(instruction.data).readBigUInt64LE(1)).toBe(25n);
+      expect(Buffer.from(instruction.data).readBigUInt64LE(12)).toBe(100n);
+      expect(Buffer.from(instruction.data).readBigUInt64LE(20)).toBe(300n);
+      expect(Buffer.from(instruction.data).readUInt32LE(28)).toBe(4);
     });
 
     it("should allow overriding the reimbursement token account", () => {
@@ -1530,6 +1589,8 @@ describe("Exposed Instructions (web3.js)", () => {
         300n,
         4,
         reimbursementTokenInfo,
+        undefined,
+        TOKEN_PROGRAM_ID,
       );
 
       expect(instruction.keys[8].pubkey.toBase58()).toBe(
@@ -1552,31 +1613,17 @@ describe("Exposed Instructions (web3.js)", () => {
         4,
         source,
         42n,
+        TOKEN_PROGRAM_ID,
       );
 
-      expect(Array.from(instruction.data)).toEqual([
-        16,
-        ...Array.from(
-          Buffer.from(
-            [25n, 100n, 300n].flatMap((value) => {
-              const out = Buffer.alloc(8);
-              out.writeBigUInt64LE(value);
-              return Array.from(out);
-            }),
-          ),
-        ),
-        4,
-        0,
-        0,
-        0,
-        ...Array.from(
-          (() => {
-            const out = Buffer.alloc(8);
-            out.writeBigUInt64LE(42n);
-            return out;
-          })(),
-        ),
-      ]);
+      expect(instruction.data).toHaveLength(40);
+      expect(instruction.data[0]).toBe(16);
+      expect(Buffer.from(instruction.data).readBigUInt64LE(1)).toBe(25n);
+      expect(Buffer.from(instruction.data).readUIntLE(9, 3)).not.toBe(0);
+      expect(Buffer.from(instruction.data).readBigUInt64LE(12)).toBe(100n);
+      expect(Buffer.from(instruction.data).readBigUInt64LE(20)).toBe(300n);
+      expect(Buffer.from(instruction.data).readUInt32LE(28)).toBe(4);
+      expect(Buffer.from(instruction.data).readBigUInt64LE(32)).toBe(42n);
     });
   });
 

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -817,7 +817,7 @@ describe("Exposed Instructions (web3.js)", () => {
     const mint = new PublicKey("11111111111111111111111111111114");
     const validator = new PublicKey("11111111111111111111111111111115");
 
-    it("should delegate the vault eata when initializing the vault in legacy flow", async () => {
+    it("should not delegate the vault eata when initializing the vault in legacy flow", async () => {
       const [vault] = deriveVault(mint);
       const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
 
@@ -828,18 +828,15 @@ describe("Exposed Instructions (web3.js)", () => {
         idempotent: false,
       });
 
-      expect(instructions[3].keys[1].pubkey.toBase58()).toBe(
-        vaultEphemeralAta.toBase58(),
-      );
-      expect(instructions[3].data[0]).toBe(4);
       expect(
-        Buffer.from(instructions[3].data.subarray(1)).equals(
-          validator.toBuffer(),
+        instructions.find(
+          (ix) =>
+            ix.data[0] === 4 && ix.keys[1]?.pubkey.equals(vaultEphemeralAta),
         ),
-      ).toBe(true);
+      ).toBeUndefined();
     });
 
-    it("should delegate the vault eata when initializing the vault in idempotent flow", async () => {
+    it("should not delegate the vault eata when initializing the vault in idempotent flow", async () => {
       const [vault] = deriveVault(mint);
       const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
 
@@ -849,15 +846,12 @@ describe("Exposed Instructions (web3.js)", () => {
         shuttleId: 7,
       });
 
-      expect(instructions[2].keys[1].pubkey.toBase58()).toBe(
-        vaultEphemeralAta.toBase58(),
-      );
-      expect(instructions[2].data[0]).toBe(4);
       expect(
-        Buffer.from(instructions[2].data.subarray(1)).equals(
-          validator.toBuffer(),
+        instructions.find(
+          (ix) =>
+            ix.data[0] === 4 && ix.keys[1]?.pubkey.equals(vaultEphemeralAta),
         ),
-      ).toBe(true);
+      ).toBeUndefined();
     });
 
     it("should use setup_and_delegate_shuttle_with_merge in idempotent flow when amount is nonzero", async () => {

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1471,7 +1471,6 @@ async function buildDelegateSplInstructions(
 
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
   const [vault] = deriveVault(mint);
-  const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
   const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
   const ownerAta = getAssociatedTokenAddressSync(
     mint,
@@ -1488,7 +1487,6 @@ async function buildDelegateSplInstructions(
     instructions.push(
       initVaultIx(vault, mint, payer, tokenProgram),
       initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
-      delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
 
@@ -1533,7 +1531,6 @@ async function buildIdempotentDelegateSplInstructions(
 
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
   const [vault] = deriveVault(mint);
-  const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
   const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
   const ownerAta = getAssociatedTokenAddressSync(
     mint,
@@ -1558,7 +1555,6 @@ async function buildIdempotentDelegateSplInstructions(
     instructions.push(
       initVaultIx(vault, mint, payer, tokenProgram),
       initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
-      delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
 

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1669,7 +1669,6 @@ export async function delegateSplWithPrivateTransfer(
 
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
   const [vault] = deriveVault(mint);
-  const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
   const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
   const [queue] = deriveTransferQueue(mint, validator);
   const ownerAta = getAssociatedTokenAddressSync(
@@ -1694,7 +1693,6 @@ export async function delegateSplWithPrivateTransfer(
     instructions.push(
       initVaultIx(vault, mint, payer, tokenProgram),
       initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
-      delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
 
@@ -1871,13 +1869,11 @@ export async function transferSpl(
 
   if (initVaultIfMissing) {
     const [vault] = deriveVault(mint);
-    const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
     const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
 
     instructions.push(
       initVaultIx(vault, mint, payer, tokenProgram),
       initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
-      delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
     );
   }
 

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -8,6 +8,7 @@ import {
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   DELEGATION_PROGRAM_ID,
+  EPHEMERAL_VAULT_ID,
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   MAGIC_CONTEXT_ID,
   MAGIC_PROGRAM_ID,
@@ -23,6 +24,7 @@ import {
 
 const TRANSFER_QUEUE_SEED = Buffer.from("queue");
 const QUEUE_REFILL_STATE_SEED = Buffer.from("queue-refill");
+const GROUP_RECEIPT_SEED = Buffer.from("group-receipt");
 const RENT_PDA_SEED = Buffer.from("rent");
 const LAMPORTS_PDA_SEED = Buffer.from("lamports");
 const INITIALIZE_TRANSFER_QUEUE_DISCRIMINATOR = 12;
@@ -90,6 +92,41 @@ export function deriveQueueVaultAta(
     ASSOCIATED_TOKEN_PROGRAM_ID,
   );
   return ata;
+}
+
+export function deriveGroupReceipt(
+  queue: PublicKey,
+  source: PublicKey,
+  groupId: number,
+): [PublicKey, number] {
+  if (!Number.isInteger(groupId) || groupId <= 0 || groupId > 0x00ff_ffff) {
+    throw new Error("groupId must be an integer between 1 and 16777215");
+  }
+
+  const groupIdBytes = Buffer.alloc(4);
+  groupIdBytes.writeUInt32LE(groupId, 0);
+
+  return PublicKey.findProgramAddressSync(
+    [GROUP_RECEIPT_SEED, queue.toBuffer(), source.toBuffer(), groupIdBytes],
+    EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+  );
+}
+
+function randomTransferGroupId(): number {
+  const cryptoObj = (globalThis as any)?.crypto;
+  let groupId = 0;
+
+  while (groupId === 0) {
+    if (cryptoObj?.getRandomValues !== undefined) {
+      const bytes = new Uint8Array(3);
+      cryptoObj.getRandomValues(bytes);
+      groupId = bytes[0] | (bytes[1] << 8) | (bytes[2] << 16);
+    } else {
+      groupId = Math.floor(Math.random() * 0x0100_0000);
+    }
+  }
+
+  return groupId;
 }
 
 /**
@@ -235,9 +272,16 @@ export function depositAndQueueTransferIx(
     throw new Error("maxDelayMs must be greater than or equal to minDelayMs");
   }
 
+  const groupId = randomTransferGroupId();
+  const groupIdBytes = Buffer.alloc(4);
+  groupIdBytes.writeUInt32LE(groupId, 0);
+  const [groupReceipt] = deriveGroupReceipt(queue, owner, groupId);
   const data = [
     DEPOSIT_AND_QUEUE_TRANSFER_DISCRIMINATOR,
     ...u64le(amount),
+    groupIdBytes[0],
+    groupIdBytes[1],
+    groupIdBytes[2],
     ...u64le(minDelayMs),
     ...u64le(maxDelayMs),
     ...u32le(split),
@@ -257,6 +301,9 @@ export function depositAndQueueTransferIx(
       { pubkey: owner, isSigner: true, isWritable: false },
       { pubkey: tokenProgram, isSigner: false, isWritable: false },
       { pubkey: reimbursementTokenInfo, isSigner: false, isWritable: true },
+      { pubkey: groupReceipt, isSigner: false, isWritable: true },
+      { pubkey: EPHEMERAL_VAULT_ID, isSigner: false, isWritable: true },
+      { pubkey: MAGIC_PROGRAM_ID, isSigner: false, isWritable: false },
     ],
     data: new Uint8Array(data),
     programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -103,8 +103,8 @@ export function deriveGroupReceipt(
     throw new Error("groupId must be an integer between 1 and 16777215");
   }
 
-  const groupIdBytes = Buffer.alloc(4);
-  groupIdBytes.writeUInt32LE(groupId, 0);
+  const groupIdBytes = Buffer.alloc(3);
+  groupIdBytes.writeUIntLE(groupId, 0, 3);
 
   return PublicKey.findProgramAddressSync(
     [GROUP_RECEIPT_SEED, queue.toBuffer(), source.toBuffer(), groupIdBytes],


### PR DESCRIPTION
## Summary
- Stop `delegateSpl` from appending vault eATA delegation after vault initialization in web3js.
- Mirror the same behavior in the `@solana/kit` SDK.
- Update both SDK test suites to assert the vault eATA delegation instruction is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queued transfers support grouping with random nonzero group IDs and a derived group-receipt; deposit-and-queue payload and accounts expanded (client call becomes async where applicable).

* **Bug Fixes**
  * Ephemeral account delegation no longer occurs during vault initialization; delegation now targets the user ephemeral ATA later in the flow.

* **Tests**
  * Tests updated to reflect new instruction layouts, account lists, data offsets, and absence of vault-eATA delegation during init.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->