### PR TITLE
feat: make transferSpl work for stealth-address as well

### DIFF
--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -43,7 +43,6 @@ import {
   lamportsDelegatedTransferIx,
   processPendingTransferQueueRefillIx,
   schedulePrivateTransferIx,
-  stealthTransferSpl,
   transferSpl,
   undelegateAndCloseShuttleEphemeralAtaIx,
   withdrawSplIx,
@@ -981,6 +980,7 @@ describe("Exposed Instructions (web3.js)", () => {
       const data = Buffer.from(privateTransferInstruction.data);
       expect(data.readUInt32LE(1)).toBe(7);
       expect(data.readBigUInt64LE(5)).toBe(1n);
+      expect(data[13]).toBe(0);
 
       const destinationField = data.subarray(14, 14 + 80);
       const validatorField = data.subarray(14 + 80 + 1, 14 + 80 + 1 + 32);
@@ -1128,14 +1128,6 @@ describe("Exposed Instructions (web3.js)", () => {
     const mint = Keypair.generate().publicKey;
     const validator = Keypair.generate().publicKey;
 
-    it("should reject on-curve stealth pool addresses", async () => {
-      expect(PublicKey.isOnCurve(to.toBuffer())).toBe(true);
-
-      await expect(
-        stealthTransferSpl(from, to, mint, 25n, { validator }),
-      ).rejects.toThrow("stealthPool must be an off-curve PDA");
-    });
-
     it("should build base-to-base stealth transfers to off-curve pool PDAs", async () => {
       const [stealthPool] = PublicKey.findProgramAddressSync(
         [Buffer.from("stealth_pool"), mint.toBuffer()],
@@ -1145,19 +1137,18 @@ describe("Exposed Instructions (web3.js)", () => {
 
       expect(PublicKey.isOnCurve(stealthPool.toBuffer())).toBe(false);
 
-      const instructions = await stealthTransferSpl(
-        from,
-        stealthPool,
-        mint,
-        25n,
-        {
-          validator,
-          shuttleId: 7,
+      const instructions = await transferSpl(from, stealthPool, mint, 25n, {
+        visibility: "private",
+        fromBalance: "base",
+        toBalance: "base",
+        validator,
+        shuttleId: 7,
+        privateTransfer: {
           minDelayMs: 100n,
           maxDelayMs: 300n,
           split: 4,
         },
-      );
+      });
 
       expect(instructions).toHaveLength(3);
       expect(instructions[0].data[0]).toBe(0);

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -1137,13 +1137,19 @@ describe("Exposed Instructions (web3.js)", () => {
 
       expect(PublicKey.isOnCurve(stealthPool.toBuffer())).toBe(false);
 
-      const instructions = await stealthTransferSpl(from, stealthPool, mint, 25n, {
-        validator,
-        shuttleId: 7,
-        minDelayMs: 100n,
-        maxDelayMs: 300n,
-        split: 4,
-      });
+      const instructions = await stealthTransferSpl(
+        from,
+        stealthPool,
+        mint,
+        25n,
+        {
+          validator,
+          shuttleId: 7,
+          minDelayMs: 100n,
+          maxDelayMs: 300n,
+          split: 4,
+        },
+      );
 
       expect(instructions).toHaveLength(3);
       expect(instructions[0].data[0]).toBe(0);

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -43,6 +43,7 @@ import {
   lamportsDelegatedTransferIx,
   processPendingTransferQueueRefillIx,
   schedulePrivateTransferIx,
+  stealthTransferSpl,
   transferSpl,
   undelegateAndCloseShuttleEphemeralAtaIx,
   withdrawSplIx,
@@ -1126,6 +1127,44 @@ describe("Exposed Instructions (web3.js)", () => {
     const to = Keypair.generate().publicKey;
     const mint = Keypair.generate().publicKey;
     const validator = Keypair.generate().publicKey;
+
+    it("should build base-to-base stealth transfers to off-curve pool PDAs", async () => {
+      const [stealthPool] = PublicKey.findProgramAddressSync(
+        [Buffer.from("stealth_pool"), mint.toBuffer()],
+        EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+      );
+      const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
+
+      expect(PublicKey.isOnCurve(stealthPool.toBuffer())).toBe(false);
+
+      const instructions = await stealthTransferSpl(from, stealthPool, mint, 25n, {
+        validator,
+        shuttleId: 7,
+        minDelayMs: 100n,
+        maxDelayMs: 300n,
+        split: 4,
+      });
+
+      expect(instructions).toHaveLength(3);
+      expect(instructions[0].data[0]).toBe(0);
+      expect(instructions[0].keys[0].pubkey.toBase58()).toBe(
+        fromEphemeralAta.toBase58(),
+      );
+      expect(instructions[1].data[0]).toBe(4);
+      expect(instructions[2].data[0]).toBe(25);
+      expect(instructions[2].keys).toHaveLength(19);
+
+      const data = Buffer.from(instructions[2].data);
+      expect(data.readUInt32LE(1)).toBe(7);
+      expect(data.readBigUInt64LE(5)).toBe(25n);
+
+      const [suffixField, endOffset] = readLengthPrefixedField(
+        data,
+        14 + 80 + 1 + 32,
+      );
+      expect(suffixField).toHaveLength(68);
+      expect(endOffset).toBe(data.length);
+    });
 
     it("should use the shuttle private transfer instruction for private base-to-base transfers", async () => {
       const [fromEphemeralAta] = deriveEphemeralAta(from, mint);

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -1128,6 +1128,14 @@ describe("Exposed Instructions (web3.js)", () => {
     const mint = Keypair.generate().publicKey;
     const validator = Keypair.generate().publicKey;
 
+    it("should reject on-curve stealth pool addresses", async () => {
+      expect(PublicKey.isOnCurve(to.toBuffer())).toBe(true);
+
+      await expect(
+        stealthTransferSpl(from, to, mint, 25n, { validator }),
+      ).rejects.toThrow("stealthPool must be an off-curve PDA");
+    });
+
     it("should build base-to-base stealth transfers to off-curve pool PDAs", async () => {
       const [stealthPool] = PublicKey.findProgramAddressSync(
         [Buffer.from("stealth_pool"), mint.toBuffer()],

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1444,6 +1444,20 @@ export interface TransferSplOptions {
   privateTransfer?: TransferSplPrivateOptions;
 }
 
+export interface StealthTransferSplOptions {
+  payer?: PublicKey;
+  validator: PublicKey;
+  tokenProgram?: PublicKey;
+  initAtasIfMissing?: boolean;
+  initVaultIfMissing?: boolean;
+  shuttleId?: number;
+  minDelayMs?: bigint;
+  maxDelayMs?: bigint;
+  split?: number;
+  exactOut?: boolean;
+  clientRefId?: bigint;
+}
+
 function randomShuttleId(): number {
   const cryptoObj = (globalThis as any)?.crypto;
   if (cryptoObj?.getRandomValues !== undefined) {
@@ -1452,6 +1466,107 @@ function randomShuttleId(): number {
     return buf[0];
   }
   return Math.floor(Math.random() * 0x1_0000_0000);
+}
+
+export async function stealthTransferSpl(
+  from: PublicKey,
+  stealthPool: PublicKey,
+  mint: PublicKey,
+  amount: bigint,
+  opts: StealthTransferSplOptions,
+): Promise<TransactionInstruction[]> {
+  const payer = opts.payer ?? from;
+  const validator = opts.validator;
+  const tokenProgram = opts.tokenProgram ?? TOKEN_PROGRAM_ID;
+  const initAtasIfMissing = opts.initAtasIfMissing ?? false;
+  const initVaultIfMissing = opts.initVaultIfMissing ?? false;
+  const shuttleId = opts.shuttleId ?? randomShuttleId();
+  const minDelayMs = opts.minDelayMs ?? 0n;
+  const maxDelayMs = opts.maxDelayMs ?? minDelayMs;
+  const split = opts.split ?? 1;
+  const exactOut = opts.exactOut ?? true;
+  const clientRefId = opts.clientRefId;
+  const instructions: TransactionInstruction[] = [];
+  const fromAta = getAssociatedTokenAddressSync(
+    mint,
+    from,
+    false,
+    tokenProgram,
+  );
+
+  if (initVaultIfMissing) {
+    const [vault] = deriveVault(mint);
+    const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
+    const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
+    const [queue] = deriveTransferQueue(mint, validator);
+
+    instructions.push(
+      initVaultIx(vault, mint, payer, tokenProgram),
+      initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
+      delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
+      toTransactionInstruction(
+        initTransferQueueIx(
+          payer,
+          queue,
+          mint,
+          validator,
+          undefined,
+          tokenProgram,
+        ),
+      ),
+    );
+  }
+
+  if (initAtasIfMissing) {
+    instructions.push(
+      createAssociatedTokenAccountIdempotentInstruction(
+        payer,
+        fromAta,
+        from,
+        mint,
+        tokenProgram,
+      ),
+    );
+  }
+
+  const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
+  const [shuttleEphemeralAta] = deriveShuttleEphemeralAta(
+    from,
+    mint,
+    shuttleId,
+  );
+  const [shuttleAta] = deriveShuttleAta(shuttleEphemeralAta, mint);
+  const shuttleWalletAta = deriveShuttleWalletAta(
+    mint,
+    shuttleEphemeralAta,
+    tokenProgram,
+  );
+
+  instructions.push(
+    initEphemeralAtaIx(fromEphemeralAta, from, mint, payer),
+    delegateEphemeralAtaIx(payer, fromEphemeralAta, validator),
+    depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferIx(
+      payer,
+      shuttleEphemeralAta,
+      shuttleAta,
+      from,
+      fromAta,
+      stealthPool,
+      shuttleWalletAta,
+      mint,
+      shuttleId,
+      amount,
+      exactOut,
+      minDelayMs,
+      maxDelayMs,
+      split,
+      validator,
+      clientRefId,
+      tokenProgram,
+    ),
+  );
+
+  return instructions;
 }
 
 async function buildDelegateSplInstructions(

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1444,20 +1444,6 @@ export interface TransferSplOptions {
   privateTransfer?: TransferSplPrivateOptions;
 }
 
-export interface StealthTransferSplOptions {
-  payer?: PublicKey;
-  validator: PublicKey;
-  tokenProgram?: PublicKey;
-  initAtasIfMissing?: boolean;
-  initVaultIfMissing?: boolean;
-  shuttleId?: number;
-  minDelayMs?: bigint;
-  maxDelayMs?: bigint;
-  split?: number;
-  exactOut?: boolean;
-  clientRefId?: bigint;
-}
-
 function randomShuttleId(): number {
   const cryptoObj = (globalThis as any)?.crypto;
   if (cryptoObj?.getRandomValues !== undefined) {
@@ -1466,111 +1452,6 @@ function randomShuttleId(): number {
     return buf[0];
   }
   return Math.floor(Math.random() * 0x1_0000_0000);
-}
-
-export async function stealthTransferSpl(
-  from: PublicKey,
-  stealthPool: PublicKey,
-  mint: PublicKey,
-  amount: bigint,
-  opts: StealthTransferSplOptions,
-): Promise<TransactionInstruction[]> {
-  if (PublicKey.isOnCurve(stealthPool.toBuffer())) {
-    throw new Error("stealthPool must be an off-curve PDA");
-  }
-
-  const payer = opts.payer ?? from;
-  const validator = opts.validator;
-  const tokenProgram = opts.tokenProgram ?? TOKEN_PROGRAM_ID;
-  const initAtasIfMissing = opts.initAtasIfMissing ?? false;
-  const initVaultIfMissing = opts.initVaultIfMissing ?? false;
-  const shuttleId = opts.shuttleId ?? randomShuttleId();
-  const minDelayMs = opts.minDelayMs ?? 0n;
-  const maxDelayMs = opts.maxDelayMs ?? minDelayMs;
-  const split = opts.split ?? 1;
-  const exactOut = opts.exactOut ?? true;
-  const clientRefId = opts.clientRefId;
-  const instructions: TransactionInstruction[] = [];
-  const fromAta = getAssociatedTokenAddressSync(
-    mint,
-    from,
-    false,
-    tokenProgram,
-  );
-
-  if (initVaultIfMissing) {
-    const [vault] = deriveVault(mint);
-    const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
-    const vaultAta = deriveVaultAta(mint, vault, tokenProgram);
-    const [queue] = deriveTransferQueue(mint, validator);
-
-    instructions.push(
-      initVaultIx(vault, mint, payer, tokenProgram),
-      initVaultAtaIx(payer, vaultAta, vault, mint, tokenProgram),
-      delegateEphemeralAtaIx(payer, vaultEphemeralAta, validator),
-      toTransactionInstruction(
-        initTransferQueueIx(
-          payer,
-          queue,
-          mint,
-          validator,
-          undefined,
-          tokenProgram,
-        ),
-      ),
-    );
-  }
-
-  if (initAtasIfMissing) {
-    instructions.push(
-      createAssociatedTokenAccountIdempotentInstruction(
-        payer,
-        fromAta,
-        from,
-        mint,
-        tokenProgram,
-      ),
-    );
-  }
-
-  const [fromEphemeralAta] = deriveEphemeralAta(from, mint);
-  const [shuttleEphemeralAta] = deriveShuttleEphemeralAta(
-    from,
-    mint,
-    shuttleId,
-  );
-  const [shuttleAta] = deriveShuttleAta(shuttleEphemeralAta, mint);
-  const shuttleWalletAta = deriveShuttleWalletAta(
-    mint,
-    shuttleEphemeralAta,
-    tokenProgram,
-  );
-
-  instructions.push(
-    initEphemeralAtaIx(fromEphemeralAta, from, mint, payer),
-    delegateEphemeralAtaIx(payer, fromEphemeralAta, validator),
-    depositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferIx(
-      payer,
-      shuttleEphemeralAta,
-      shuttleAta,
-      from,
-      fromAta,
-      stealthPool,
-      shuttleWalletAta,
-      mint,
-      shuttleId,
-      amount,
-      exactOut,
-      minDelayMs,
-      maxDelayMs,
-      split,
-      validator,
-      clientRefId,
-      tokenProgram,
-    ),
-  );
-
-  return instructions;
 }
 
 async function buildDelegateSplInstructions(
@@ -1892,13 +1773,10 @@ export async function transferSpl(
   const exactOut = opts.privateTransfer?.exactOut ?? true;
   const clientRefId = opts.privateTransfer?.clientRefId;
 
-  const fromAta = getAssociatedTokenAddressSync(
-    mint,
-    from,
-    false,
-    tokenProgram,
-  );
-  const toAta = getAssociatedTokenAddressSync(mint, to, false, tokenProgram);
+  const fromAta = () =>
+    getAssociatedTokenAddressSync(mint, from, false, tokenProgram);
+  const toAta = () =>
+    getAssociatedTokenAddressSync(mint, to, false, tokenProgram);
 
   if (opts.fromBalance === "ephemeral") {
     switch (opts.visibility) {
@@ -1935,7 +1813,7 @@ export async function transferSpl(
                 queue,
                 vault,
                 mint,
-                fromAta,
+                fromAta(),
                 vaultAta,
                 to,
                 from,
@@ -1954,8 +1832,8 @@ export async function transferSpl(
         if (opts.toBalance === "ephemeral") {
           return [
             createTransferInstruction(
-              fromAta,
-              toAta,
+              fromAta(),
+              toAta(),
               from,
               amount,
               [],
@@ -1970,8 +1848,8 @@ export async function transferSpl(
         if (opts.toBalance === "ephemeral") {
           return [
             createTransferInstruction(
-              fromAta,
-              toAta,
+              fromAta(),
+              toAta(),
               from,
               amount,
               [],
@@ -2028,7 +1906,7 @@ export async function transferSpl(
     instructions.push(
       createAssociatedTokenAccountIdempotentInstruction(
         payer,
-        fromAta,
+        fromAta(),
         from,
         mint,
         tokenProgram,
@@ -2061,7 +1939,7 @@ export async function transferSpl(
             shuttleEphemeralAta,
             shuttleAta,
             from,
-            fromAta,
+            fromAta(),
             to,
             shuttleWalletAta,
             mint,
@@ -2085,7 +1963,7 @@ export async function transferSpl(
           instructions.push(
             createAssociatedTokenAccountIdempotentInstruction(
               payer,
-              toAta,
+              toAta(),
               to,
               mint,
               tokenProgram,
@@ -2115,8 +1993,8 @@ export async function transferSpl(
             shuttleEphemeralAta,
             shuttleAta,
             from,
-            fromAta,
-            toAta,
+            fromAta(),
+            toAta(),
             shuttleWalletAta,
             mint,
             shuttleId,
@@ -2135,8 +2013,8 @@ export async function transferSpl(
         return [
           ...instructions,
           createTransferInstruction(
-            fromAta,
-            toAta,
+            fromAta(),
+            toAta(),
             from,
             amount,
             [],

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1475,6 +1475,10 @@ export async function stealthTransferSpl(
   amount: bigint,
   opts: StealthTransferSplOptions,
 ): Promise<TransactionInstruction[]> {
+  if (PublicKey.isOnCurve(stealthPool.toBuffer())) {
+    throw new Error("stealthPool must be an off-curve PDA");
+  }
+
   const payer = opts.payer ?? from;
   const validator = opts.validator;
   const tokenProgram = opts.tokenProgram ?? TOKEN_PROGRAM_ID;


### PR DESCRIPTION
- ~Add `stealthTransferSpl()` which is designed specifically for stealth-transfer.~
  - ~I didn't overload the existing `transferSpl` with stealth-transfer as well, because it is already too complex.~ 
  
- Adds support for private `transferSpl` calls whose destination is an **off-curve** stealth pool PDA. 
  - It is done **without changing the function signature of `transferSpl`**.
  - Instead, previously, `transferSpl` eagerly derived both source and destination ATAs at the top of the function. That caused routes targeting off-curve PDA recipients to fail before reaching the private shuttle transfer path, even though that path does not need a destination ATA for the recipient. **This change lazily derives ATAs only in the routes that actually use them.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correctness and routing behavior for SPL token stealth transfers by updating how source and destination associated accounts are resolved during instruction construction.

* **Tests**
  * Expanded coverage for stealth transfer instruction serialization, including additional byte-level checks and validation of stealth pool derivation and encrypted suffix structure.
  * Replaced an earlier base-to-base test scenario with assertions that confirm the expected instruction count/opcode markers and proper source account usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->