### PR TITLE
Align SPL helper behavior across TS SDKs

### DIFF
--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -1210,7 +1210,7 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(instructions[2].data?.[0]).toBe(24);
     });
 
-    it("should initialize and delegate the receiver eata for private base-to-ephemeral transfers when requested", async () => {
+    it("should initialize permission and delegate the receiver eata for private base-to-ephemeral transfers when requested", async () => {
       const [toEphemeralAta] = await deriveEphemeralAta(to, mint);
 
       const instructions = await transferSpl(from, to, mint, 25n, {
@@ -1222,14 +1222,16 @@ describe("Exposed Instructions (@solana/kit)", () => {
         initIfMissing: true,
       });
 
-      expect(instructions).toHaveLength(4);
+      expect(instructions).toHaveLength(5);
       expect(instructions[0].data?.[0]).toBe(1);
       expect(instructions[0].accounts?.[2].address).toBe(to);
       expect(instructions[1].data?.[0]).toBe(0);
       expect(instructions[1].accounts?.[0].address).toBe(toEphemeralAta);
-      expect(instructions[2].data?.[0]).toBe(4);
-      expect(instructions[2].accounts?.[1].address).toBe(toEphemeralAta);
-      expect(instructions[3].data?.[0]).toBe(24);
+      expect(instructions[2].data?.[0]).toBe(6);
+      expect(instructions[2].accounts?.[0].address).toBe(toEphemeralAta);
+      expect(instructions[3].data?.[0]).toBe(4);
+      expect(instructions[3].accounts?.[1].address).toBe(toEphemeralAta);
+      expect(instructions[4].data?.[0]).toBe(24);
     });
 
     it("should ignore initAtasIfMissing on ephemeral-source transfers", async () => {
@@ -1465,9 +1467,22 @@ describe("Exposed Instructions (@solana/kit)", () => {
         mockAddress,
         groupId,
       );
+      const addressEncoder = getAddressEncoder();
+      const groupIdSeed = Buffer.alloc(4);
+      groupIdSeed.writeUInt32LE(groupId, 0);
+      const [expectedGroupReceipt] = await getProgramDerivedAddress({
+        programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+        seeds: [
+          Buffer.from("group-receipt"),
+          addressEncoder.encode(queue),
+          addressEncoder.encode(mockAddress),
+          groupIdSeed,
+        ],
+      });
 
       expect(instruction.accounts).toHaveLength(12);
       expect(groupId).not.toBe(0);
+      expect(groupReceipt).toBe(expectedGroupReceipt);
       expect(instruction.accounts?.[8].address).toBe(source);
       expect(instruction.accounts?.[8].role).toBe(AccountRole.WRITABLE);
       expect(instruction.accounts?.[9].address).toBe(groupReceipt);

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1753,6 +1753,7 @@ export async function transferSpl(
           instructions.push(
             initVaultAtaIx(payer, toAta, to, mint),
             initEphemeralAtaIx(toEphemeralAta, to, mint, payer),
+            await createEataPermissionIx(toEphemeralAta, payer),
             await delegateIx(payer, toEphemeralAta, validator),
           );
         }

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -98,7 +98,7 @@ export async function deriveGroupReceipt(
   }
 
   const addressEncoder = getAddressEncoder();
-  const groupIdBytes = new Uint8Array(u32le(groupId).slice(0, 3));
+  const groupIdBytes = new Uint8Array(u32le(groupId));
   const [groupReceipt, bump] = await getProgramDerivedAddress({
     programAddress: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
     seeds: [

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -1333,7 +1333,7 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(instructions[2].data[0]).toBe(24);
     });
 
-    it("should initialize and delegate the receiver eata for private base-to-ephemeral transfers when requested", async () => {
+    it("should initialize permission and delegate the receiver eata for private base-to-ephemeral transfers when requested", async () => {
       const [toEphemeralAta] = deriveEphemeralAta(to, mint);
 
       const instructions = await transferSpl(from, to, mint, 25n, {
@@ -1345,18 +1345,22 @@ describe("Exposed Instructions (web3.js)", () => {
         initIfMissing: true,
       });
 
-      expect(instructions).toHaveLength(4);
+      expect(instructions).toHaveLength(5);
       expect(instructions[0].data[0]).toBe(1);
       expect(instructions[0].keys[2].pubkey.toBase58()).toBe(to.toBase58());
       expect(instructions[1].data[0]).toBe(0);
       expect(instructions[1].keys[0].pubkey.toBase58()).toBe(
         toEphemeralAta.toBase58(),
       );
-      expect(instructions[2].data[0]).toBe(4);
-      expect(instructions[2].keys[1].pubkey.toBase58()).toBe(
+      expect(instructions[2].data[0]).toBe(6);
+      expect(instructions[2].keys[0].pubkey.toBase58()).toBe(
         toEphemeralAta.toBase58(),
       );
-      expect(instructions[3].data[0]).toBe(24);
+      expect(instructions[3].data[0]).toBe(4);
+      expect(instructions[3].keys[1].pubkey.toBase58()).toBe(
+        toEphemeralAta.toBase58(),
+      );
+      expect(instructions[4].data[0]).toBe(24);
     });
 
     it("should ignore initAtasIfMissing on ephemeral-source transfers", async () => {
@@ -1547,10 +1551,22 @@ describe("Exposed Instructions (web3.js)", () => {
       );
       const groupId = Buffer.from(instruction.data).readUIntLE(9, 3);
       const [groupReceipt] = deriveGroupReceipt(queue, mockPublicKey, groupId);
+      const groupIdSeed = Buffer.alloc(4);
+      groupIdSeed.writeUInt32LE(groupId, 0);
+      const [expectedGroupReceipt] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("group-receipt"),
+          queue.toBuffer(),
+          mockPublicKey.toBuffer(),
+          groupIdSeed,
+        ],
+        EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+      );
 
       expect(instruction).toBeInstanceOf(TransactionInstruction);
       expect(instruction.keys).toHaveLength(12);
       expect(groupId).not.toBe(0);
+      expect(groupReceipt.toBase58()).toBe(expectedGroupReceipt.toBase58());
       expect(instruction.keys[8].pubkey.toBase58()).toBe(source.toBase58());
       expect(instruction.keys[8].isWritable).toBe(true);
       expect(instruction.keys[9].pubkey.toBase58()).toBe(

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1972,6 +1972,7 @@ export async function transferSpl(
               tokenProgram,
             ),
             initEphemeralAtaIx(toEphemeralAta, to, mint, payer),
+            createEataPermissionIx(toEphemeralAta, payer),
             delegateEphemeralAtaIx(payer, toEphemeralAta, validator),
           );
         }

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/transferQueue.ts
@@ -103,8 +103,8 @@ export function deriveGroupReceipt(
     throw new Error("groupId must be an integer between 1 and 16777215");
   }
 
-  const groupIdBytes = Buffer.alloc(3);
-  groupIdBytes.writeUIntLE(groupId, 0, 3);
+  const groupIdBytes = Buffer.alloc(4);
+  groupIdBytes.writeUInt32LE(groupId, 0);
 
   return PublicKey.findProgramAddressSync(
     [GROUP_RECEIPT_SEED, queue.toBuffer(), source.toBuffer(), groupIdBytes],


### PR DESCRIPTION
## Summary
- Add receiver eATA permission initialization before delegation in the private base-to-ephemeral `transferSpl` route.
- Mirror the web3js behavior in the `@solana/kit` SDK.
- Keep group receipt derivation aligned with the web3js reference and add assertions that cover the seed derivation.

## Rust SDK
The Rust SDK exposes the individual permission, delegate, and shuttle setup builders rather than a high-level `transferSpl` composite route, so there is no matching Rust composite path to update in this change.
