### PR TITLE
Validate top up escrow inputs

### DIFF
--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -445,6 +445,29 @@ describe("Exposed Instructions (@solana/kit)", () => {
       expect(amount).toBe(BigInt(largeAmount));
     });
 
+    it("should reject invalid amount and index values", () => {
+      expect(() =>
+        createTopUpEscrowInstruction(mockAddress, mockAddress, mockAddress, -1),
+      ).toThrow("amount must be a non-negative safe integer");
+      expect(() =>
+        createTopUpEscrowInstruction(
+          mockAddress,
+          mockAddress,
+          mockAddress,
+          Number.MAX_SAFE_INTEGER + 1,
+        ),
+      ).toThrow("amount must be a non-negative safe integer");
+      expect(() =>
+        createTopUpEscrowInstruction(
+          mockAddress,
+          mockAddress,
+          mockAddress,
+          1,
+          256,
+        ),
+      ).toThrow("index must fit in u8");
+    });
+
     it("should include correct account keys", () => {
       const instruction = createTopUpEscrowInstruction(
         mockAddress,

--- a/ts/kit/src/instructions/delegation-program/topUpEphemeralBalance.ts
+++ b/ts/kit/src/instructions/delegation-program/topUpEphemeralBalance.ts
@@ -28,6 +28,16 @@ export function createTopUpEscrowInstruction(
     { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
   ];
 
+  if (!Number.isSafeInteger(amount) || amount < 0) {
+    throw new Error("amount must be a non-negative safe integer");
+  }
+  if (
+    index !== undefined &&
+    (!Number.isInteger(index) || index < 0 || index > 0xff)
+  ) {
+    throw new Error("index must fit in u8");
+  }
+
   const [instructionData] = serializeTopUpEphemeralBalanceInstructionData({
     amount: BigInt(amount),
     index: index ?? 255,

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -445,6 +445,34 @@ describe("Exposed Instructions (web3.js)", () => {
       expect(amount).toBe(BigInt(largeAmount));
     });
 
+    it("should reject invalid amount and index values", () => {
+      expect(() =>
+        createTopUpEscrowInstruction(
+          mockPublicKey,
+          mockPublicKey,
+          mockPublicKey,
+          -1,
+        ),
+      ).toThrow("amount must be a non-negative safe integer");
+      expect(() =>
+        createTopUpEscrowInstruction(
+          mockPublicKey,
+          mockPublicKey,
+          mockPublicKey,
+          Number.MAX_SAFE_INTEGER + 1,
+        ),
+      ).toThrow("amount must be a non-negative safe integer");
+      expect(() =>
+        createTopUpEscrowInstruction(
+          mockPublicKey,
+          mockPublicKey,
+          mockPublicKey,
+          1,
+          256,
+        ),
+      ).toThrow("index must fit in u8");
+    });
+
     it("should include correct account keys", () => {
       const instruction = createTopUpEscrowInstruction(
         mockPublicKey,

--- a/ts/web3js/src/instructions/delegation-program/topUpEphemeralBalance.ts
+++ b/ts/web3js/src/instructions/delegation-program/topUpEphemeralBalance.ts
@@ -32,6 +32,16 @@ export function createTopUpEscrowInstruction(
     { pubkey: SystemProgram.programId, isWritable: false, isSigner: false },
   ];
 
+  if (!Number.isSafeInteger(amount) || amount < 0) {
+    throw new Error("amount must be a non-negative safe integer");
+  }
+  if (
+    index !== undefined &&
+    (!Number.isInteger(index) || index < 0 || index > 0xff)
+  ) {
+    throw new Error("index must fit in u8");
+  }
+
   const instructionData = serializeTopUpEphemeralBalanceInstructionData({
     amount: BigInt(amount),
     index: index ?? 255,


### PR DESCRIPTION
createTopUpEscrowInstruction converted the amount to bigint before serialization, so negative numbers could wrap into a u64 and unsafe JS numbers could be serialized after precision loss. Out of range index values also reached the u8 write path.

This adds validation for amount and index in both TypeScript SDK variants, with regression coverage for invalid values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation for top-up escrow operations to reject invalid amounts (negative values or numbers exceeding safe integer limits) and invalid index values (outside 0-255 range) with descriptive error messages.

* **Tests**
  * Added comprehensive test coverage across multiple test suites for input validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->