### PR TITLE
fix: register `ephemeral_accounts` test in `Cargo.toml`

### DIFF
--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -159,6 +159,11 @@ name = "spl_test"
 path = "../tests/spl_test.rs"
 required-features = ["spl", "access-control", "modular-sdk"]
 
+[[test]]
+name = "ephemeral_accounts"
+path = "../tests/ephemeral_accounts.rs"
+required-features = ["anchor"]
+
 [dev-dependencies]
 bincode = { workspace = true }
 sdk = { workspace = true }


### PR DESCRIPTION
Added missing test target for `ephemeral_accounts.rs` integration tests.

The file `rust/tests/ephemeral_accounts.rs` contains compile-time tests for the `#[ephemeral_accounts]` macro, but it was not registered in `Cargo.toml` under `[[test]]`.

Added a new test target:
```toml
[[test]]
name = "ephemeral_accounts"
path = "../tests/ephemeral_accounts.rs"
required-features = ["anchor"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new feature-gated integration test for ephemeral account behavior.
  * The test only runs when the relevant feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->