### PR TITLE
feat: redirect to to ephemeral system program calls associated with ephemeral accounts

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2663,9 +2663,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc8fba0307c90b91b70c9ed06d4242d6c4159f331b2f05bf8f875c2a94e0e98"
+version = "0.13.6"
+source = "git+https://github.com/magicblock-labs/magicblock-validator.git?rev=6de1da9aa28f19735945d6e0860f64294de2020a#6de1da9aa28f19735945d6e0860f64294de2020a"
 dependencies = [
  "bincode 1.3.3",
  "const-crypto",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,7 +34,8 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 
 # Magicblock
 magicblock-delegation-program-api = { version = "3.0.0", default-features = false }
-magicblock-magic-program-api = { version = "0.10.1", default-features = false }
+#magicblock-magic-program-api = { version = "0.10.1", default-features = false }
+magicblock-magic-program-api = { git = "https://github.com/magicblock-labs/magicblock-validator.git", rev = "6de1da9aa28f19735945d6e0860f64294de2020a" }
 ephemeral-vrf-sdk = { version = "0.4.1", default-features = false }
 ephemeral-vrf-sdk-vrf-macro = { version = "0.4.1", default-features = false }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,7 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 
 # Magicblock
 magicblock-delegation-program-api = { version = "3.0.0", default-features = false }
+# TODO(edwin): uncomment and update version once validator released
 #magicblock-magic-program-api = { version = "0.10.1", default-features = false }
 magicblock-magic-program-api = { git = "https://github.com/magicblock-labs/magicblock-validator.git", rev = "6de1da9aa28f19735945d6e0860f64294de2020a" }
 ephemeral-vrf-sdk = { version = "0.4.1", default-features = false }

--- a/rust/pinocchio/src/consts.rs
+++ b/rust/pinocchio/src/consts.rs
@@ -18,6 +18,10 @@ pub const MAGIC_CONTEXT_ID: Address =
 pub const EPHEMERAL_VAULT_ID: Address =
     Address::new_from_array(pubkey!("MagicVau1t999999999999999999999999999999999"));
 
+/// The ephemeral system program ID
+pub const EPHEMERAL_SYSTEM_PROGRAM_ID: Address =
+    Address::new_from_array(pubkey!("EphSystem1111111111111111111111111111111111"));
+
 /// The seed of the authority account PDA.
 pub const DELEGATION_RECORD: &[u8] = b"delegation";
 

--- a/rust/pinocchio/src/ephemeral_accounts.rs
+++ b/rust/pinocchio/src/ephemeral_accounts.rs
@@ -20,22 +20,22 @@
 //! use ephemeral_rollups_pinocchio::ephemeral_accounts::EphemeralAccount;
 //!
 //! // Create: both sponsor and ephemeral are PDAs - provide seeds for both
-//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.magic_program)
+//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.esp_program)
 //!     .with_signers(&[&sponsor_signer, &ephemeral_signer])
 //!     .create(1000)?;
 //!
 //! // Resize/Close: only sponsor needs to sign - only sponsor seeds needed
-//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.magic_program)
+//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.esp_program)
 //!     .with_signers(&[&sponsor_signer])
 //!     .resize(2000)?;
 //!
 //! // Create with oncurve sponsor (signed tx), ephemeral is PDA
-//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.magic_program)
+//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.esp_program)
 //!     .with_signers(&[&ephemeral_signer])
 //!     .create(1000)?;
 //!
 //! // Resize/Close with oncurve sponsor - no seeds needed
-//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.magic_program)
+//! EphemeralAccount::new(&ctx.sponsor, &ctx.ephemeral, &ctx.vault, &ctx.esp_program)
 //!     .resize(2000)?;
 //! ```
 
@@ -49,9 +49,9 @@ use pinocchio::{
 const ACCOUNT_OVERHEAD: u32 = 60;
 const EPHEMERAL_RENT_PER_BYTE: u64 = 32;
 
-const CREATE_EPHEMERAL_ACCOUNT_DISCRIMINATOR: u32 = 12;
-const RESIZE_EPHEMERAL_ACCOUNT_DISCRIMINATOR: u32 = 13;
-const CLOSE_EPHEMERAL_ACCOUNT_DISCRIMINATOR: u32 = 14;
+const CREATE_EPHEMERAL_ACCOUNT_DISCRIMINATOR: u32 = 0;
+const RESIZE_EPHEMERAL_ACCOUNT_DISCRIMINATOR: u32 = 1;
+const CLOSE_EPHEMERAL_ACCOUNT_DISCRIMINATOR: u32 = 2;
 
 // -----------------
 // Utility Functions
@@ -85,7 +85,7 @@ pub struct EphemeralAccount<'a> {
     sponsor: &'a AccountView,
     ephemeral: &'a AccountView,
     vault: &'a AccountView,
-    magic_program: &'a AccountView,
+    esp_program: &'a AccountView,
     signer_seeds: &'a [Signer<'a, 'a>],
 }
 
@@ -97,18 +97,18 @@ impl<'a> EphemeralAccount<'a> {
     /// * `sponsor` - Account paying rent (must be signer for all operations)
     /// * `ephemeral` - Account to create/modify (must be signer only on create)
     /// * `vault` - Rent vault ([`crate::consts::EPHEMERAL_VAULT_ID`])
-    /// * `magic_program` - Magic program ([`crate::consts::MAGIC_PROGRAM_ID`])
+    /// * `esp_program` - Ephemeral system program ([`crate::consts::EPHEMERAL_SYSTEM_PROGRAM_ID`])
     pub fn new(
         sponsor: &'a AccountView,
         ephemeral: &'a AccountView,
         vault: &'a AccountView,
-        magic_program: &'a AccountView,
+        esp_program: &'a AccountView,
     ) -> Self {
         Self {
             sponsor,
             ephemeral,
             vault,
-            magic_program,
+            esp_program,
             signer_seeds: &[],
         }
     }
@@ -158,7 +158,7 @@ impl<'a> EphemeralAccount<'a> {
 
     fn invoke(&self, data: &[u8], ephemeral_is_signer: bool) -> ProgramResult {
         let ix = InstructionView {
-            program_id: self.magic_program.address(),
+            program_id: self.esp_program.address(),
             data,
             accounts: &[
                 InstructionAccount::writable_signer(self.sponsor.address()),

--- a/rust/sdk/src/ephemeral_accounts.rs
+++ b/rust/sdk/src/ephemeral_accounts.rs
@@ -39,11 +39,9 @@
 //!     .resize(2000)?;
 //! ```
 
-use crate::{
-    compat::{self, AsModern, Compat, Modern},
-    consts::MAGIC_PROGRAM_ID,
-};
-use magicblock_magic_program_api::{instruction::MagicBlockInstruction, EPHEMERAL_RENT_PER_BYTE};
+use crate::compat::{self, AsModern, Compat, Modern};
+use magicblock_magic_program_api::instruction::EphemeralSystemInstruction;
+use magicblock_magic_program_api::{EPHEMERAL_RENT_PER_BYTE, EPHEMERAL_SYSTEM_PROGRAM_ID};
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     program::invoke_signed,
@@ -126,7 +124,7 @@ impl<'a, 'info> EphemeralAccount<'a, 'info> {
     /// Provide seeds via [`Self::with_signer_seeds`] if ephemeral is a PDA.
     pub fn create(&self, data_len: u32) -> compat::ProgramResult {
         self.invoke(
-            MagicBlockInstruction::CreateEphemeralAccount { data_len },
+            EphemeralSystemInstruction::CreateEphemeralAccount { data_len },
             true, // ephemeral must sign on create
         )
     }
@@ -137,7 +135,7 @@ impl<'a, 'info> EphemeralAccount<'a, 'info> {
     /// Shrinking: vault refunds excess rent to sponsor.
     pub fn resize(&self, new_data_len: u32) -> compat::ProgramResult {
         self.invoke(
-            MagicBlockInstruction::ResizeEphemeralAccount { new_data_len },
+            EphemeralSystemInstruction::ResizeEphemeralAccount { new_data_len },
             false,
         )
     }
@@ -146,16 +144,16 @@ impl<'a, 'info> EphemeralAccount<'a, 'info> {
     ///
     /// All rent is refunded from vault to sponsor.
     pub fn close(&self) -> compat::ProgramResult {
-        self.invoke(MagicBlockInstruction::CloseEphemeralAccount, false)
+        self.invoke(EphemeralSystemInstruction::CloseEphemeralAccount, false)
     }
 
     fn invoke(
         &self,
-        instruction: MagicBlockInstruction,
+        instruction: EphemeralSystemInstruction,
         ephemeral_is_signer: bool,
     ) -> compat::ProgramResult {
         let ix = Instruction::new_with_bincode(
-            *MAGIC_PROGRAM_ID.as_modern(),
+            *EPHEMERAL_SYSTEM_PROGRAM_ID.as_modern(),
             &instruction,
             vec![
                 AccountMeta::new(*self.sponsor.key.as_modern(), true),


### PR DESCRIPTION
Validator moved out handling of ephemeral accounts into separate builtin. Here we update sdk accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for interacting with the ephemeral system program.
  * Added a public identifier for the ephemeral system program.
  * Updated ephemeral account creation, resizing, and closing operations to use the new system program interface.

* **Documentation**
  * Updated ephemeral account usage examples and account-handling guidance to reflect the new interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->