### PR TITLE
fix: reject getCommitmentSignature when scheduling tx failed

### DIFF
--- a/ts/kit/src/__test__/connection.test.ts
+++ b/ts/kit/src/__test__/connection.test.ts
@@ -27,7 +27,7 @@ const mockLifetimeConstraint = {
 const mockRpc = {
   sendTransaction: vi.fn(() => ({ send: vi.fn(async () => mockSignature) })),
   getTransaction: vi.fn(() => ({
-    send: vi.fn(async () => ({ meta: { logMessages: ["log1"] } })),
+    send: vi.fn(async () => ({ meta: { err: null, logMessages: ["log1"] } })),
   })),
   getLatestBlockhash: vi.fn(() => ({
     send: vi.fn(async () => ({
@@ -313,6 +313,23 @@ describe("Connection", () => {
     const connection = await Connection.create("http://localhost");
     const sig = await connection.getCommitmentSignature(mockSignature);
     expect(sig).toBe(mockSignature);
+  });
+
+  it("should reject getCommitmentSignature when the scheduling transaction failed", async () => {
+    const connection = await Connection.create("http://localhost");
+    vi.mocked(mockRpc.getTransaction).mockReturnValueOnce({
+      send: vi.fn(async () => ({
+        meta: {
+          err: { InstructionError: [1, "Custom"] },
+          logMessages: [
+            "Program log: ScheduledCommitSent signature: would-look-valid",
+          ],
+        },
+      })),
+    } as any);
+    await expect(
+      connection.getCommitmentSignature(mockSignature),
+    ).rejects.toThrow(/Transaction failed; commitment was not scheduled/);
   });
 
   it("should getBalance", async () => {

--- a/ts/kit/src/connection.ts
+++ b/ts/kit/src/connection.ts
@@ -367,7 +367,8 @@ export class Connection {
    * @param signature - The transaction signature of the accounts commitment transaction to the base layer.
    * @returns A `Promise<string>` that resolves with the commitment signature found in the commit logs.
    *
-   * @throws {Error} If the transaction or its metadata cannot be found, or if the
+   * @throws {Error} If the transaction or its metadata cannot be found, if the
+   *                 scheduling transaction failed (`meta.err`), or if the
    *                 expected log messages are missing from either scheduling or commit stages.
    */
   public async getCommitmentSignature(
@@ -382,6 +383,14 @@ export class Connection {
 
     if (txSchedulingSgn?.meta == null) {
       throw new Error("Transaction not found or meta is null");
+    }
+    // A later instruction can fail after magic-program logs ScheduledCommitSent.
+    // In that case the overall transaction fails and nothing was scheduled, so
+    // we must not return a signature that will never land on the ER.
+    if (txSchedulingSgn.meta.err != null) {
+      throw new Error(
+        "Transaction failed; commitment was not scheduled (ScheduledCommitSent logs from earlier instructions are not reliable when the transaction errors)",
+      );
     }
     const scheduledCommitSgn = parseScheduleCommitsLogsMessage(
       txSchedulingSgn.meta.logMessages ?? [],
@@ -400,6 +409,11 @@ export class Connection {
 
     if (txCommitInfo?.meta == null) {
       throw new Error("Transaction not found or meta is null");
+    }
+    if (txCommitInfo.meta.err != null) {
+      throw new Error(
+        "Scheduled commit transaction failed; commitment signature is not available",
+      );
     }
 
     const commitSignature = parseCommitsLogsMessage(

--- a/ts/web3js/src/utils.ts
+++ b/ts/web3js/src/utils.ts
@@ -18,6 +18,14 @@ export async function GetCommitmentSignature(
   if (txSchedulingSgn?.meta == null) {
     throw new Error("Transaction not found or meta is null");
   }
+  // A later instruction can fail after magic-program logs ScheduledCommitSent.
+  // In that case the overall transaction fails and nothing was scheduled, so
+  // we must not return a signature that will never land on the ER.
+  if (txSchedulingSgn.meta.err != null) {
+    throw new Error(
+      "Transaction failed; commitment was not scheduled (ScheduledCommitSent logs from earlier instructions are not reliable when the transaction errors)",
+    );
+  }
 
   const scheduledCommitSgn = parseScheduleCommitsLogsMessage(
     txSchedulingSgn.meta.logMessages ?? [],
@@ -38,6 +46,11 @@ export async function GetCommitmentSignature(
   );
   if (txCommitInfo?.meta == null) {
     throw new Error("Transaction not found or meta is null");
+  }
+  if (txCommitInfo.meta.err != null) {
+    throw new Error(
+      "Scheduled commit transaction failed; commitment signature is not available",
+    );
   }
 
   const commitSignature = parseCommitsLogsMessage(


### PR DESCRIPTION
## Summary
`getCommitmentSignature` / `GetCommitmentSignature` previously trusted `ScheduledCommitSent` logs even when the **overall transaction failed** (`meta.err != null`).

That matches the failure mode in #75:
1. Instruction 1 (commit) logs `ScheduledCommitSent signature: ...`
2. Instruction 2 fails
3. Transaction errors → nothing scheduled on ER
4. SDK still returned a signature that will never land

## Fix
- If the scheduling transaction has `meta.err`, throw a clear error instead of parsing logs
- Same guard on the follow-up scheduled-commit transaction
- Applied in:
  - `ts/kit/src/connection.ts` (`Connection.getCommitmentSignature`)
  - `ts/web3js/src/utils.ts` (`GetCommitmentSignature`)

## Tests
- Added unit test: rejects when scheduling tx `meta.err` is set even if logs contain `ScheduledCommitSent`
- `yarn test` (kit `connection.test.ts`): **14/14 passed**

Fixes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commitment status handling for failed scheduling transactions.
  * Improved detection of failed scheduled-commit transactions.
  * Added clearer errors when a commitment was not scheduled or its signature is unavailable.
  * Prevented misleading success results when transaction logs appear valid despite transaction failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->