### PR TITLE
feat: upgrade dlp to 3.1.0 to expose RequestUndelegation API

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2630,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288904a9950bd20f27f0ef934f320ab1410bd35a6d5c9cf138eca276442b6b2e"
+checksum = "bea16e41e04319201919afca98dd4241b18549f2db0c68f58e4bc531537b5dab"
 dependencies = [
  "bincode 1.3.3",
  "borsh 0.10.4",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 
 
 # Magicblock
-magicblock-delegation-program-api = { version = "3.0.0", default-features = false }
+magicblock-delegation-program-api = { version = "3.1.0", default-features = false }
 magicblock-magic-program-api = { version = "0.10.1", default-features = false }
 ephemeral-vrf-sdk = { version = "0.4.1", default-features = false }
 ephemeral-vrf-sdk-vrf-macro = { version = "0.4.1", default-features = false }

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -47,9 +47,11 @@ access-control = ["num-derive", "num-traits", "thiserror"]
 # spl support.
 spl = ["spl-associated-token-account-interface", "encryption"]
 
+instruction = ["magicblock-delegation-program-api/instruction"]
+
 encryption = [
     "magicblock-delegation-program-api/encryption",
-    "magicblock-delegation-program-api/instruction",
+    "instruction",
 ]
 
 # backward compatability support (can be combined with [access-control | encryption])

--- a/rust/sdk/scripts/test-combinations.sh
+++ b/rust/sdk/scripts/test-combinations.sh
@@ -56,6 +56,7 @@ build_no_default() {
 
 build
 build_no_default "solana-system-interface"
+build_no_default "solana-system-interface,instruction"
 
 build "backward-compat"
 
@@ -92,6 +93,9 @@ build "anchor-compat,access-control"
 
 build "access-control"
 build "access-control,backward-compat"
+
+build "instruction"
+build "instruction,backward-compat"
 
 build "encryption"
 build "encryption,backward-compat"

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -30,6 +30,8 @@ pub mod spl;
 
 pub use dlp_api;
 pub use dlp_api::args::CallHandlerArgs;
+#[cfg(feature = "instruction")]
+pub use dlp_api::instruction_builder;
 pub use dlp_api::pda;
 pub use dlp_api::{
     commit_record_seeds_from_delegated_account, commit_state_seeds_from_delegated_account,

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -36,7 +36,8 @@ pub use dlp_api::{
     delegate_buffer_seeds_from_delegated_account, delegation_metadata_seeds_from_delegated_account,
     delegation_record_seeds_from_delegated_account, ephemeral_balance_seeds_from_payer,
     fees_vault_seeds, program_config_seeds_from_program_id,
-    undelegate_buffer_seeds_from_delegated_account, validator_fees_vault_seeds_from_validator,
+    undelegate_buffer_seeds_from_delegated_account,
+    undelegation_request_seeds_from_delegated_account, validator_fees_vault_seeds_from_validator,
 };
 pub use magicblock_magic_program_api::args::{
     ActionArgs, BaseActionArgs, CommitAndUndelegateArgs, CommitTypeArgs, MagicBaseIntentArgs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the delegation API integration to the latest supported version.
  * Improved formatting for exported delegation helpers without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->