### PR TITLE
feat: custom challenges

### DIFF
--- a/ts/kit/src/__test__/access-control.test.ts
+++ b/ts/kit/src/__test__/access-control.test.ts
@@ -240,12 +240,7 @@ describe("Access Control (@solana/kit)", () => {
 
       const signMessage = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
 
-      await getAuthToken(
-        mockRpcUrl,
-        mockAddress,
-        signMessage,
-        mockTemplate,
-      );
+      await getAuthToken(mockRpcUrl, mockAddress, signMessage, mockTemplate);
 
       const firstCall = (global.fetch as any).mock.calls[0];
       expect(firstCall[0]).toContain(

--- a/ts/kit/src/__test__/access-control.test.ts
+++ b/ts/kit/src/__test__/access-control.test.ts
@@ -200,6 +200,58 @@ describe("Access Control (@solana/kit)", () => {
       expect(body.pubkey).toBe(mockAddress.toString());
       expect(body.challenge).toBe(mockChallenge);
     });
+
+    it("should not include template in challenge request by default", async () => {
+      const mockChallenge = "test-challenge";
+      const mockToken = "test-token";
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          json: async () => ({ challenge: mockChallenge }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: async () => ({ token: mockToken }),
+        });
+
+      const signMessage = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+      await getAuthToken(mockRpcUrl, mockAddress, signMessage);
+
+      const firstCall = (global.fetch as any).mock.calls[0];
+      expect(firstCall[0]).not.toContain("template=");
+    });
+
+    it("should include the template in the challenge request when provided", async () => {
+      const mockChallenge = "test-challenge";
+      const mockToken = "test-token";
+      const mockTemplate = "Custom login\n{timestamp}\nUser: {pubkey}";
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          json: async () => ({ challenge: mockChallenge }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: async () => ({ token: mockToken }),
+        });
+
+      const signMessage = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+      await getAuthToken(
+        mockRpcUrl,
+        mockAddress,
+        signMessage,
+        mockTemplate,
+      );
+
+      const firstCall = (global.fetch as any).mock.calls[0];
+      expect(firstCall[0]).toContain(
+        new URLSearchParams({ template: mockTemplate }).toString(),
+      );
+    });
   });
 
   describe("verifyTeeIntegrity", () => {

--- a/ts/kit/src/access-control/auth.ts
+++ b/ts/kit/src/access-control/auth.ts
@@ -18,19 +18,28 @@ interface AuthLoginResponse {
  * @param rpcUrl - The URL of the RPC server
  * @param publicKey - The public key of the user
  * @param signMessage - The function to sign a message
+ * @param template - Optional custom challenge template to sign; must contain
+ * a `{timestamp}` placeholder. Defaults to the service's standard challenge.
  * @returns The auth token and its expiration time
  */
 export async function getAuthToken(
   rpcUrl: string,
   publicKey: Address,
   signMessage: (message: Uint8Array) => Promise<Uint8Array>,
+  template?: string,
 ): Promise<{ token: string; expiresAt: number }> {
   // Import this way because bs58 is an ECMAScript module
   const bs58 = (await import("bs58")).default;
 
   // Getting the challenge from the RPC
+  const challengeParams = new URLSearchParams({
+    pubkey: publicKey.toString(),
+  });
+  if (template != null && template !== "") {
+    challengeParams.set("template", template);
+  }
   const challengeResponse = await fetch(
-    `${rpcUrl}/auth/challenge?pubkey=${publicKey.toString()}`,
+    `${rpcUrl}/auth/challenge?${challengeParams.toString()}`,
   );
   const { challenge, error }: AuthChallengeResponse =
     await challengeResponse.json();

--- a/ts/kit/src/access-control/auth.ts
+++ b/ts/kit/src/access-control/auth.ts
@@ -36,6 +36,9 @@ export async function getAuthToken(
     pubkey: publicKey.toString(),
   });
   if (template != null && template !== "") {
+    if (!template.includes("{timestamp}")) {
+      throw new Error("Template must contain a {timestamp} placeholder");
+    }
     challengeParams.set("template", template);
   }
   const challengeResponse = await fetch(

--- a/ts/web3js/src/__test__/access-control.test.ts
+++ b/ts/web3js/src/__test__/access-control.test.ts
@@ -240,12 +240,7 @@ describe("Access Control (web3.js)", () => {
 
       const signMessage = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
 
-      await getAuthToken(
-        mockRpcUrl,
-        mockPublicKey,
-        signMessage,
-        mockTemplate,
-      );
+      await getAuthToken(mockRpcUrl, mockPublicKey, signMessage, mockTemplate);
 
       const firstCall = (global.fetch as any).mock.calls[0];
       expect(firstCall[0]).toContain(

--- a/ts/web3js/src/__test__/access-control.test.ts
+++ b/ts/web3js/src/__test__/access-control.test.ts
@@ -200,6 +200,58 @@ describe("Access Control (web3.js)", () => {
       expect(body.pubkey).toBe(mockPublicKey.toString());
       expect(body.challenge).toBe(mockChallenge);
     });
+
+    it("should not include template in challenge request by default", async () => {
+      const mockChallenge = "test-challenge";
+      const mockToken = "test-token";
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          json: async () => ({ challenge: mockChallenge }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: async () => ({ token: mockToken }),
+        });
+
+      const signMessage = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+      await getAuthToken(mockRpcUrl, mockPublicKey, signMessage);
+
+      const firstCall = (global.fetch as any).mock.calls[0];
+      expect(firstCall[0]).not.toContain("template=");
+    });
+
+    it("should include the template in the challenge request when provided", async () => {
+      const mockChallenge = "test-challenge";
+      const mockToken = "test-token";
+      const mockTemplate = "Custom login\n{timestamp}\nUser: {pubkey}";
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          json: async () => ({ challenge: mockChallenge }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: async () => ({ token: mockToken }),
+        });
+
+      const signMessage = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+      await getAuthToken(
+        mockRpcUrl,
+        mockPublicKey,
+        signMessage,
+        mockTemplate,
+      );
+
+      const firstCall = (global.fetch as any).mock.calls[0];
+      expect(firstCall[0]).toContain(
+        new URLSearchParams({ template: mockTemplate }).toString(),
+      );
+    });
   });
 
   describe("verifyTeeIntegrity", () => {

--- a/ts/web3js/src/access-control/auth.ts
+++ b/ts/web3js/src/access-control/auth.ts
@@ -36,6 +36,9 @@ export async function getAuthToken(
     pubkey: publicKey.toString(),
   });
   if (template != null && template !== "") {
+    if (!template.includes("{timestamp}")) {
+      throw new Error("Template must contain a {timestamp} placeholder");
+    }
     challengeParams.set("template", template);
   }
   const challengeResponse = await fetch(

--- a/ts/web3js/src/access-control/auth.ts
+++ b/ts/web3js/src/access-control/auth.ts
@@ -18,19 +18,28 @@ interface AuthLoginResponse {
  * @param rpcUrl - The URL of the RPC server
  * @param publicKey - The public key of the user
  * @param signMessage - The function to sign a message
+ * @param template - Optional custom challenge template to sign; must contain
+ * a `{timestamp}` placeholder. Defaults to the service's standard challenge.
  * @returns The auth token and its expiration time
  */
 export async function getAuthToken(
   rpcUrl: string,
   publicKey: PublicKey,
   signMessage: (message: Uint8Array) => Promise<Uint8Array>,
+  template?: string,
 ): Promise<{ token: string; expiresAt: number }> {
   // Import this way because bs58 is an ECMAScript module
   const bs58 = (await import("bs58")).default;
 
   // Getting the challenge from the RPC
+  const challengeParams = new URLSearchParams({
+    pubkey: publicKey.toString(),
+  });
+  if (template != null && template !== "") {
+    challengeParams.set("template", template);
+  }
   const challengeResponse = await fetch(
-    `${rpcUrl}/auth/challenge?pubkey=${publicKey.toString()}`,
+    `${rpcUrl}/auth/challenge?${challengeParams.toString()}`,
   );
   const { challenge, error }: AuthChallengeResponse =
     await challengeResponse.json();


### PR DESCRIPTION
Allows users to create custom challenges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Authentication token requests now support an optional template parameter.
  - When provided, the template is included in the authentication challenge request; requests without a template remain unchanged.

- **Tests**
  - Added coverage confirming the authentication challenge URL omits `template` when not provided and includes a URL-encoded `template` when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->