### PR TITLE
feat: hydra cranks

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1484,6 +1484,7 @@ dependencies = [
  "bincode 2.0.1",
  "ephemeral-rollups-sdk",
  "ephemeral-vrf-sdk",
+ "hydra-api",
  "magicblock-delegation-program-api",
  "magicblock-magic-program-api",
  "pinocchio 0.11.2",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1494,6 +1494,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ephemeral-rollups-pinocchio"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a175e532d887f6ae43fd6d314ced9d9c44e714dc38692cb312403897c6b6bdce"
+dependencies = [
+ "bincode 2.0.1",
+ "pinocchio 0.11.2",
+ "pinocchio-system 0.6.1",
+ "solana-address 2.6.1",
+]
+
+[[package]]
 name = "ephemeral-rollups-sdk"
 version = "0.17.0"
 dependencies = [
@@ -1511,6 +1523,7 @@ dependencies = [
  "ephemeral-vrf-sdk-vrf-macro",
  "five8 0.2.1",
  "getrandom 0.2.17",
+ "hydra-api",
  "magicblock-delegation-program-api",
  "magicblock-magic-program-api",
  "num-derive",
@@ -2113,6 +2126,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hydra-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25017a85c1e189844ff869fe606fa7621e7346a28329661f03a2b33b8bf44465"
+dependencies = [
+ "ephemeral-rollups-pinocchio 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pinocchio 0.11.2",
+ "solana-account-info 3.1.1",
+ "solana-address 2.6.1",
+ "solana-cpi 3.1.0",
+ "solana-instruction 3.4.0",
+ "solana-program-error 3.0.1",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,10 +35,10 @@ ephemeral-rollups-sdk-attribute-action = { path = "action-attribute", version = 
 ephemeral-vrf-sdk = { path = "vrf-sdk", version = "=0.17.0", default-features = false }
 ephemeral-vrf-sdk-vrf-macro = { path = "vrf-macro", version = "=0.17.0", default-features = false }
 
-
 # Magicblock
 magicblock-delegation-program-api = { version = "3.1.0", default-features = false }
 magicblock-magic-program-api = { version = "0.10.1", default-features = false }
+hydra-api = "0.2.0"
 
 ## External crates
 anchor-lang-compat = { package = "anchor-lang", version = ">=0.28.0, <1.0.0" }

--- a/rust/pinocchio/Cargo.toml
+++ b/rust/pinocchio/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 
 [dependencies]
 bincode = { version = "2.0.1", default-features = false, features = ["derive"] }
-hydra-api = { workspace = true, features = ["cpi-pinocchio"] }
+hydra-api = { workspace = true, features = ["cpi-pinocchio", "ephemeral"] }
 magicblock-delegation-program-api = { workspace = true, optional = true }
 pinocchio = { workspace = true }
 pinocchio-system = { workspace = true, default-features = false }

--- a/rust/pinocchio/Cargo.toml
+++ b/rust/pinocchio/Cargo.toml
@@ -12,14 +12,15 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bincode = { version = "2.0.1", default-features = false, features = ["derive"] }
+hydra-api = { workspace = true, features = ["cpi-pinocchio"] }
+magicblock-delegation-program-api = { workspace = true, optional = true }
 pinocchio = { workspace = true }
 pinocchio-system = { workspace = true, default-features = false }
 solana-address = { version = ">=2, <3", default-features = false, features = [
     "curve25519",
     "decode",
 ] }
-bincode = { version = "2.0.1", default-features = false, features = ["derive"] }
-magicblock-delegation-program-api = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode1 = { package = "bincode", version = "1.3" }

--- a/rust/pinocchio/src/crank/hydra.rs
+++ b/rust/pinocchio/src/crank/hydra.rs
@@ -1,0 +1,4 @@
+pub use hydra_api::{
+    cpi::{base::pinocchio as base, ephemeral::pinocchio as ephemeral},
+    instruction::CreateArgs,
+};

--- a/rust/pinocchio/src/crank/legacy.rs
+++ b/rust/pinocchio/src/crank/legacy.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use core::mem::MaybeUninit;
 
 use pinocchio::{
@@ -138,6 +140,9 @@ impl<'a> ScheduleCrankArgs<'a> {
     }
 }
 
+#[deprecated(
+    note = "Use `ephemeral_rollups_pinocchio::crank::hydra::ephemeral::create::create` instead"
+)]
 pub struct ScheduleCrankCpi<'a> {
     pub payer: AccountView,
     pub magic_program: AccountView,
@@ -275,6 +280,7 @@ impl<'a> ScheduleCrankCpi<'a> {
     }
 }
 
+#[deprecated(note = "Use `ephemeral_rollups_pinocchio::crank::hydra::ephemeral::create` instead")]
 pub struct ScheduleCrankCpiBuilder<'a> {
     payer: AccountView,
     magic_program: AccountView,
@@ -369,6 +375,7 @@ impl<'a> ScheduleCrankCpiBuilder<'a> {
     }
 }
 
+#[deprecated(note = "Use `ephemeral_rollups_pinocchio::crank::hydra::ephemeral::cancel` instead")]
 pub struct CancelCrankCpi {
     pub authority: AccountView,
     pub task_context: AccountView,

--- a/rust/pinocchio/src/crank/mod.rs
+++ b/rust/pinocchio/src/crank/mod.rs
@@ -1,0 +1,4 @@
+pub mod hydra;
+mod legacy;
+
+pub use legacy::*;

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -49,10 +49,7 @@ spl = ["spl-associated-token-account-interface", "encryption"]
 
 instruction = ["magicblock-delegation-program-api/instruction"]
 
-encryption = [
-    "magicblock-delegation-program-api/encryption",
-    "instruction",
-]
+encryption = ["magicblock-delegation-program-api/encryption", "instruction"]
 
 # backward compatability support (can be combined with [access-control | encryption])
 backward-compat = [
@@ -71,7 +68,7 @@ vrf = [
     "dep:ephemeral-vrf-sdk",
     "ephemeral-vrf-sdk-vrf-macro/ephemeral-rollups-sdk",
 ]
-crank = []
+crank = ["hydra-api"]
 modular-sdk = [
     "solana-account",
     "solana-account-info",
@@ -92,6 +89,7 @@ anchor-support = []
 anchor-lang-compat = { workspace = true, optional = true }
 anchor-lang-current = { workspace = true, optional = true }
 # borsh = "0.10.4"
+
 bincode = { workspace = true }
 bytemuck = { workspace = true }
 ephemeral-rollups-sdk-attribute-delegate = { workspace = true }
@@ -101,6 +99,10 @@ ephemeral-rollups-sdk-attribute-commit = { workspace = true }
 ephemeral-rollups-sdk-attribute-action = { workspace = true }
 ephemeral-vrf-sdk = { workspace = true, optional = true }
 ephemeral-vrf-sdk-vrf-macro = { workspace = true, optional = true }
+hydra-api = { workspace = true, optional = true, features = [
+    "cpi-native",
+    "ephemeral",
+] }
 solana-program = { workspace = true }
 solana-address = { workspace = true }
 solana-account = { workspace = true, optional = true }

--- a/rust/sdk/src/crank/hydra.rs
+++ b/rust/sdk/src/crank/hydra.rs
@@ -1,0 +1,4 @@
+pub use hydra_api::{
+    cpi::{base::native as base, ephemeral::native as ephemeral},
+    instruction::CreateArgs,
+};

--- a/rust/sdk/src/crank/legacy.rs
+++ b/rust/sdk/src/crank/legacy.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use magicblock_magic_program_api::{args::ScheduleTaskArgs, instruction::MagicBlockInstruction};
 use solana_program::{
     instruction::{AccountMeta, Instruction},
@@ -6,6 +8,9 @@ use solana_program::{
 
 use crate::compat::{self, AsModern, Compat, Modern};
 
+#[deprecated(
+    note = "Use `ephemeral_rollups_sdk::crank::hydra::ephemeral::create::CreateCrankCpi` instead"
+)]
 pub struct ScheduleCrankCpi<'a> {
     pub payer: &'a compat::AccountInfo<'a>,
     pub magic_program: &'a compat::AccountInfo<'a>,
@@ -59,6 +64,9 @@ impl<'a> ScheduleCrankCpi<'a> {
     }
 }
 
+#[deprecated(
+    note = "Use `ephemeral_rollups_sdk::crank::hydra::ephemeral::cancel::CancelCrankCpi` instead"
+)]
 pub struct CancelCrankCpi<'a> {
     pub authority: &'a compat::AccountInfo<'a>,
     pub task_context: &'a compat::AccountInfo<'a>,

--- a/rust/sdk/src/crank/legacy.rs
+++ b/rust/sdk/src/crank/legacy.rs
@@ -13,8 +13,8 @@ use crate::compat::{self, AsModern, Compat, Modern};
     note = "Use `ephemeral_rollups_sdk::crank::hydra::ephemeral::create::CreateCrankCpi` instead"
 )]
 pub struct ScheduleCrankCpi<'a, 'b> {
-    pub payer: compat::AccountInfo<'a>,
-    pub magic_program: compat::AccountInfo<'a>,
+    pub payer: &'a compat::AccountInfo<'a>,
+    pub magic_program: &'a compat::AccountInfo<'a>,
     pub instruction_accounts: &'b [compat::AccountInfo<'a>],
     pub args: ScheduleTaskArgs,
 }
@@ -38,13 +38,13 @@ impl<'a, 'b> ScheduleCrankCpi<'a, 'b> {
     }
 
     pub fn invoke(&self) -> compat::ProgramResult {
-        let accounts = Self::build_accounts(self.payer.clone(), self.instruction_accounts);
+        let accounts = Self::build_accounts(self.payer, self.instruction_accounts);
 
         invoke(&self.instruction().modern(), &accounts.modern()).compat()
     }
 
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> compat::ProgramResult {
-        let accounts = Self::build_accounts(self.payer.clone(), self.instruction_accounts);
+        let accounts = Self::build_accounts(self.payer, self.instruction_accounts);
 
         invoke_signed(
             &self.instruction().modern(),
@@ -55,11 +55,11 @@ impl<'a, 'b> ScheduleCrankCpi<'a, 'b> {
     }
 
     fn build_accounts(
-        payer: compat::AccountInfo<'a>,
+        payer: &compat::AccountInfo<'a>,
         instruction_accounts: &'b [compat::AccountInfo<'a>],
     ) -> Vec<compat::AccountInfo<'a>> {
         let mut accounts = Vec::with_capacity(1 + instruction_accounts.len());
-        accounts.push(payer);
+        accounts.push(payer.clone());
         accounts.extend_from_slice(instruction_accounts);
         accounts
     }
@@ -162,8 +162,8 @@ mod tests {
         let instruction_accounts = [task_context];
 
         let instruction = ScheduleCrankCpi {
-            payer: payer,
-            magic_program: magic_program,
+            payer: &payer,
+            magic_program: &magic_program,
             instruction_accounts: &instruction_accounts,
             args: ScheduleTaskArgs {
                 task_id: 7,

--- a/rust/sdk/src/crank/legacy.rs
+++ b/rust/sdk/src/crank/legacy.rs
@@ -1,6 +1,7 @@
 #![allow(deprecated)]
 
-use magicblock_magic_program_api::{args::ScheduleTaskArgs, instruction::MagicBlockInstruction};
+pub use magicblock_magic_program_api::args::ScheduleTaskArgs;
+use magicblock_magic_program_api::instruction::MagicBlockInstruction;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     program::{invoke, invoke_signed},
@@ -11,14 +12,14 @@ use crate::compat::{self, AsModern, Compat, Modern};
 #[deprecated(
     note = "Use `ephemeral_rollups_sdk::crank::hydra::ephemeral::create::CreateCrankCpi` instead"
 )]
-pub struct ScheduleCrankCpi<'a> {
-    pub payer: &'a compat::AccountInfo<'a>,
-    pub magic_program: &'a compat::AccountInfo<'a>,
-    pub instruction_accounts: &'a [compat::AccountInfo<'a>],
+pub struct ScheduleCrankCpi<'a, 'b> {
+    pub payer: compat::AccountInfo<'a>,
+    pub magic_program: compat::AccountInfo<'a>,
+    pub instruction_accounts: &'b [compat::AccountInfo<'a>],
     pub args: ScheduleTaskArgs,
 }
 
-impl<'a> ScheduleCrankCpi<'a> {
+impl<'a, 'b> ScheduleCrankCpi<'a, 'b> {
     pub fn instruction(&self) -> compat::Instruction {
         let mut accounts = Vec::with_capacity(1 + self.instruction_accounts.len());
         accounts.push(AccountMeta::new(*self.payer.key.as_modern(), true));
@@ -37,13 +38,13 @@ impl<'a> ScheduleCrankCpi<'a> {
     }
 
     pub fn invoke(&self) -> compat::ProgramResult {
-        let accounts = Self::build_accounts(self.payer, self.instruction_accounts);
+        let accounts = Self::build_accounts(self.payer.clone(), self.instruction_accounts);
 
         invoke(&self.instruction().modern(), &accounts.modern()).compat()
     }
 
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> compat::ProgramResult {
-        let accounts = Self::build_accounts(self.payer, self.instruction_accounts);
+        let accounts = Self::build_accounts(self.payer.clone(), self.instruction_accounts);
 
         invoke_signed(
             &self.instruction().modern(),
@@ -54,11 +55,11 @@ impl<'a> ScheduleCrankCpi<'a> {
     }
 
     fn build_accounts(
-        payer: &'a compat::AccountInfo<'a>,
-        instruction_accounts: &'a [compat::AccountInfo<'a>],
+        payer: compat::AccountInfo<'a>,
+        instruction_accounts: &'b [compat::AccountInfo<'a>],
     ) -> Vec<compat::AccountInfo<'a>> {
         let mut accounts = Vec::with_capacity(1 + instruction_accounts.len());
-        accounts.push(payer.clone());
+        accounts.push(payer);
         accounts.extend_from_slice(instruction_accounts);
         accounts
     }
@@ -161,8 +162,8 @@ mod tests {
         let instruction_accounts = [task_context];
 
         let instruction = ScheduleCrankCpi {
-            payer: &payer,
-            magic_program: &magic_program,
+            payer: payer,
+            magic_program: magic_program,
             instruction_accounts: &instruction_accounts,
             args: ScheduleTaskArgs {
                 task_id: 7,

--- a/rust/sdk/src/crank/mod.rs
+++ b/rust/sdk/src/crank/mod.rs
@@ -1,0 +1,4 @@
+pub mod hydra;
+mod legacy;
+
+pub use legacy::*;

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -12,6 +12,7 @@ compile_error!("feature `anchor-modern` cannot be combined with `backward-compat
 pub mod anchor;
 pub mod consts;
 pub mod cpi;
+#[cfg(feature = "crank")]
 pub mod crank;
 pub mod delegate_args;
 pub mod ephem;

--- a/ts/kit/src/__test__/connection.test.ts
+++ b/ts/kit/src/__test__/connection.test.ts
@@ -326,7 +326,7 @@ describe("Connection", () => {
           ],
         },
       })),
-    } as any);
+    } as unknown as ReturnType<typeof mockRpc.getTransaction>);
     await expect(
       connection.getCommitmentSignature(mockSignature),
     ).rejects.toThrow(/Transaction failed; commitment was not scheduled/);


### PR DESCRIPTION
Reexports the hydra SDK while preserving the current way of scheduling cranks

Closes #285 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hydra crank support for native and Pinocchio integrations.
  * Added APIs for creating crank instructions and accessing base and ephemeral CPI operations.
  * Crank functionality is now available through the SDK’s optional crank feature.
  * Added support for sharing crank instruction arguments across integrations.

* **Deprecations**
  * Deprecated legacy crank scheduling and cancellation helpers in favor of Hydra-based APIs.
  * Preserved legacy interfaces for compatibility while guiding callers toward the new replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->