### PR TITLE
feat: default vrf request randomness to scoped identity

### DIFF
--- a/rust/pinocchio/src/vrf/instruction.rs
+++ b/rust/pinocchio/src/vrf/instruction.rs
@@ -127,7 +127,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use ephemeral_vrf_sdk::instructions::{
-        create_request_scoped_randomness_ix, RequestRandomnessParams,
+        create_request_randomness_ix, RequestRandomnessParams,
     };
     use pinocchio::account::RuntimeAccount;
     use pinocchio::Address;
@@ -162,7 +162,7 @@ mod tests {
 
         // Build the canonical instruction first; it is the source of truth for the
         // program-identity, system-program and slot-hashes account keys.
-        let ix = create_request_scoped_randomness_ix(RequestRandomnessParams {
+        let ix = create_request_randomness_ix(RequestRandomnessParams {
             payer: Pubkey::new_from_array(payer_key),
             oracle_queue: Pubkey::new_from_array(oracle_key),
             callback_program_id: Pubkey::new_from_array(callback_program),

--- a/rust/pinocchio/src/vrf/types.rs
+++ b/rust/pinocchio/src/vrf/types.rs
@@ -138,7 +138,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use ephemeral_vrf_sdk::instructions::{
-        create_request_high_priority_scoped_randomness_ix, create_request_scoped_randomness_ix,
+        create_request_high_priority_scoped_randomness_ix, create_request_randomness_ix,
         RequestRandomnessParams,
     };
     use ephemeral_vrf_sdk::types::SerializableAccountMeta as SdkMeta;
@@ -227,7 +227,7 @@ mod tests {
             &args,
             REQUEST_SCOPED_RANDOMNESS_DISCRIMINATOR,
         );
-        let ix = create_request_scoped_randomness_ix(canonical(
+        let ix = create_request_randomness_ix(canonical(
             caller_seed,
             callback_program,
             &disc,
@@ -258,7 +258,7 @@ mod tests {
             &args,
             REQUEST_SCOPED_RANDOMNESS_DISCRIMINATOR,
         );
-        let ix = create_request_scoped_randomness_ix(canonical(
+        let ix = create_request_randomness_ix(canonical(
             caller_seed,
             callback_program,
             &disc,
@@ -288,7 +288,7 @@ mod tests {
             &args,
             REQUEST_SCOPED_RANDOMNESS_DISCRIMINATOR,
         );
-        let ix = create_request_scoped_randomness_ix(canonical(
+        let ix = create_request_randomness_ix(canonical(
             caller_seed,
             callback_program,
             &disc,
@@ -349,7 +349,7 @@ mod tests {
             &[],
             REQUEST_SCOPED_RANDOMNESS_DISCRIMINATOR,
         );
-        let ix = create_request_scoped_randomness_ix(canonical(
+        let ix = create_request_randomness_ix(canonical(
             caller_seed,
             callback_program,
             &disc,
@@ -401,7 +401,7 @@ mod tests {
             buf
         };
 
-        let ix = create_request_scoped_randomness_ix(canonical(
+        let ix = create_request_randomness_ix(canonical(
             caller_seed,
             callback_program,
             &disc,

--- a/rust/vrf-sdk/src/instructions.rs
+++ b/rust/vrf-sdk/src/instructions.rs
@@ -44,33 +44,37 @@ fn build_request_ix(params: RequestRandomnessParams) -> compat::Instruction {
     .compat()
 }
 
-#[deprecated(
-    note = "Legacy global-identity request (high priority). Use create_request_high_priority_scoped_randomness_ix (or the #[vrf] macro)."
-)]
+/// Requests randomness using the scoped (per-callback-program) VRF identity, regular priority.
+///
+/// This is the default request builder. The fulfillment signs the callback with the scoped
+/// identity PDA ([`crate::consts::scoped_vrf_identity`]) rather than the global one, so the
+/// callback must validate that PDA (see the `#[vrf_callback]` macro). For the legacy
+/// global-identity behavior, use [`create_request_legacy_randomness_ix`].
 pub fn create_request_randomness_ix(params: RequestRandomnessParams) -> compat::Instruction {
+    let mut ix = build_request_ix(params);
+    ix.data[0] = 10;
+    ix
+}
+
+/// Legacy global-identity randomness request (high priority).
+#[deprecated(
+    note = "Legacy global-identity request (high priority). Use create_request_randomness_ix (scoped, regular) or create_request_high_priority_scoped_randomness_ix."
+)]
+pub fn create_request_legacy_randomness_ix(
+    params: RequestRandomnessParams,
+) -> compat::Instruction {
     build_request_ix(params)
 }
 
+/// Legacy global-identity randomness request (regular priority).
 #[deprecated(
-    note = "Legacy global-identity request (regular priority). Use create_request_scoped_randomness_ix (or the #[vrf] macro)."
+    note = "Legacy global-identity request (regular priority). Use create_request_randomness_ix (scoped, regular)."
 )]
 pub fn create_request_regular_randomness_ix(
     params: RequestRandomnessParams,
 ) -> compat::Instruction {
     let mut ix = build_request_ix(params);
     ix.data[0] = 8;
-    ix
-}
-
-/// Scoped (per-callback identity) randomness request, regular priority.
-///
-/// The fulfillment signs the callback with the scoped identity PDA
-/// ([`crate::consts::scoped_vrf_identity`]) instead of the global one, so the callback
-/// must validate that PDA (see the `#[vrf_callback]` macro). This is the default for new
-/// integrations.
-pub fn create_request_scoped_randomness_ix(params: RequestRandomnessParams) -> compat::Instruction {
-    let mut ix = build_request_ix(params);
-    ix.data[0] = 10;
     ix
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated builders for regular-priority and legacy randomness requests.
  - The default randomness request now creates a scoped, regular-priority request.
  - High-priority scoped randomness requests remain supported.

- **Breaking Changes**
  - Removed the previous scoped randomness request builder; use the default randomness request builder instead.

- **Deprecations**
  - Added a deprecated legacy randomness request builder for applications that require the former global-identity, high-priority behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->