### PR TITLE
docs(rust): fix repository links in crate READMEs

### DIFF
--- a/rust/resolver/README.md
+++ b/rust/resolver/README.md
@@ -4,6 +4,6 @@ This crate provides connection resolution utilities for Magicblock's Ephemeral R
 
 - Crate: `magic-resolver`
 - Docs: https://docs.magicblock.gg/
-- Repository: https://github.com/magicblock-labs/delegation-program
+- Repository: https://github.com/magicblock-labs/ephemeral-rollups-sdk
 
 For a high-level overview and examples, see the repository README at the project root.

--- a/rust/sdk/README.md
+++ b/rust/sdk/README.md
@@ -4,6 +4,6 @@ This crate provides helper utilities and attributes to integrate with Magicblock
 
 - Crate: `ephemeral-rollups-sdk`
 - Docs: [https://docs.magicblock.xyz/](https://docs.magicblock.xyz/)
-- Repository: https://github.com/magicblock-labs/delegation-program
+- Repository: https://github.com/magicblock-labs/ephemeral-rollups-sdk
 
 For a high-level overview and examples, see the repository README at the project root.


### PR DESCRIPTION
Updates the repository links in `rust/sdk/README.md` and `rust/resolver/README.md` to match the canonical repository defined in `rust/Cargo.toml`.

This keeps the crate documentation consistent with the workspace metadata and ensures contributors are directed to the correct repository for issues, source code, and PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository links in the resolver and SDK README files.
  * Added a link to the project’s high-level overview documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->