### PR TITLE
feat: export programs

### DIFF
--- a/rust/pinocchio/src/vrf/instruction.rs
+++ b/rust/pinocchio/src/vrf/instruction.rs
@@ -126,9 +126,7 @@ mod tests {
     use alloc::vec;
     use alloc::vec::Vec;
 
-    use ephemeral_vrf_sdk::instructions::{
-        create_request_randomness_ix, RequestRandomnessParams,
-    };
+    use ephemeral_vrf_sdk::instructions::{create_request_randomness_ix, RequestRandomnessParams};
     use pinocchio::account::RuntimeAccount;
     use pinocchio::Address;
     use solana_program::pubkey::Pubkey;

--- a/rust/pinocchio/src/vrf/types.rs
+++ b/rust/pinocchio/src/vrf/types.rs
@@ -349,13 +349,8 @@ mod tests {
             &[],
             REQUEST_SCOPED_RANDOMNESS_DISCRIMINATOR,
         );
-        let ix = create_request_randomness_ix(canonical(
-            caller_seed,
-            callback_program,
-            &disc,
-            &[],
-            &[],
-        ));
+        let ix =
+            create_request_randomness_ix(canonical(caller_seed, callback_program, &disc, &[], &[]));
         assert_eq!(ours, ix.data);
     }
 

--- a/rust/sdk/src/anchor.rs
+++ b/rust/sdk/src/anchor.rs
@@ -23,3 +23,23 @@ impl anchor_lang::Id for MagicProgram {
         crate::consts::MAGIC_PROGRAM_ID.to_bytes().into()
     }
 }
+
+#[cfg(feature = "access-control")]
+pub struct PermissionProgram;
+
+#[cfg(feature = "access-control")]
+impl anchor_lang::Id for PermissionProgram {
+    fn id() -> anchor_lang::prelude::Pubkey {
+        crate::consts::PERMISSION_PROGRAM_ID.to_bytes().into()
+    }
+}
+
+#[cfg(feature = "spl")]
+pub struct EsplProgram;
+
+#[cfg(feature = "spl")]
+impl anchor_lang::Id for EsplProgram {
+    fn id() -> anchor_lang::prelude::Pubkey {
+        crate::consts::ESPL_TOKEN_PROGRAM_ID.to_bytes().into()
+    }
+}

--- a/rust/vrf-sdk/src/instructions.rs
+++ b/rust/vrf-sdk/src/instructions.rs
@@ -60,9 +60,7 @@ pub fn create_request_randomness_ix(params: RequestRandomnessParams) -> compat::
 #[deprecated(
     note = "Legacy global-identity request (high priority). Use create_request_randomness_ix (scoped, regular) or create_request_high_priority_scoped_randomness_ix."
 )]
-pub fn create_request_legacy_randomness_ix(
-    params: RequestRandomnessParams,
-) -> compat::Instruction {
+pub fn create_request_legacy_randomness_ix(params: RequestRandomnessParams) -> compat::Instruction {
     build_request_ix(params)
 }
 


### PR DESCRIPTION
Closes #269 

Exports `PermissionProgram` and `EsplProgram` for Anchor to use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the Permission and ESPL token programs when their respective features are enabled.
  * Enables integrations to reference these programs through the SDK’s standard program interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->