### PR TITLE
ci: use shared Magic Lab project automation

### DIFF
--- a/.github/workflows/auto_add_to_board.yml
+++ b/.github/workflows/auto_add_to_board.yml
@@ -1,0 +1,19 @@
+name: Magic Lab Project Automation
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled, unlabeled]
+  pull_request:
+    types: [opened, reopened, labeled, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  magic-lab:
+    name: Update Magic Lab
+    uses: magicblock-labs/.github/.github/workflows/magic_lab_automation.yml@21cae0c2ecb071828423f673076e887f8a5fe63d
+    secrets:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary

Add the caller for the shared Magic Lab project automation workflow.

This standardizes automatic project insertion, author assignment, P0-P3 priority synchronization, and linked-issue closure after pull-request merges.

The reusable workflow is pinned to immutable commit 21cae0c2ecb071828423f673076e887f8a5fe63d.

## Rollout requirement

Grant this repository access to the ADD_TO_PROJECT_PAT organization secret and its fine-grained token, then disable the repository-specific native Magic Lab project workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated project board management for newly created, reopened, transferred, labeled, or closed issues and pull requests.
  * Improved consistency by automatically processing relevant repository activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->