### PR TITLE
fix(deps): pin uuid to ^11.1.1 to resolve GHSA-w5hq-g745-h8pq

### DIFF
--- a/ts/kit/package.json
+++ b/ts/kit/package.json
@@ -51,5 +51,8 @@
     "tweetnacl": "^1.0.3",
     "typescript": "^5.3.0"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "resolutions": {
+    "uuid": "^11.1.1"
+  }
 }

--- a/ts/kit/yarn.lock
+++ b/ts/kit/yarn.lock
@@ -3177,10 +3177,10 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 vite-node@3.2.4:
   version "3.2.4"

--- a/ts/web3js/package.json
+++ b/ts/web3js/package.json
@@ -50,5 +50,8 @@
     "typescript": "^5.3.0"
   },
   "optionalDependencies": {},
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "resolutions": {
+    "uuid": "^11.1.1"
+  }
 }

--- a/ts/web3js/yarn.lock
+++ b/ts/web3js/yarn.lock
@@ -2983,10 +2983,10 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 vite-node@3.2.4:
   version "3.2.4"


### PR DESCRIPTION
## What changed
Pin `uuid` to `^11.1.1` via yarn `resolutions` in both `ts/web3js` and `ts/kit` packages.

## Why
`uuid` versions below 11.1.1 have a missing buffer bounds check in v3/v5/v6 (GHSA-w5hq-g745-h8pq). It's reachable transitively via `jayson`/`rpc-websockets` in both SDK packages. No upstream fix is currently available directly from `@solana/web3.js`, so this pins the dependency without waiting on that bump.

## Compatibility
None — uuid is never imported directly by the SDK code, only pulled in transitively.

## Validation
- web3js: full test suite passes (143/143)
- kit: full test suite passes (135/135)
- npm audit: moderate findings reduced 5→1 (web3js), 3→2 (kit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure consistent behavior across supported toolkit and web3 integrations.
  * Improved reliability by standardizing a shared underlying utility version across both packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->