### PR TITLE
fix: support token program override in undelegateIx

### DIFF
--- a/ts/kit/src/__test__/instructions.test.ts
+++ b/ts/kit/src/__test__/instructions.test.ts
@@ -44,6 +44,7 @@ import {
   processPendingTransferQueueRefillIx,
   schedulePrivateTransferIx,
   transferSpl,
+  undelegateIx,
   undelegateAndCloseShuttleEphemeralAtaIx,
   withdrawSplIx,
   withdrawSpl,
@@ -57,6 +58,7 @@ import {
   HYDRA_PROGRAM_ID,
   PERMISSION_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
 } from "../constants";
 import {
   delegateBufferPdaFromDelegatedAccountAndOwnerProgram,
@@ -78,6 +80,9 @@ function readLengthPrefixedField(
 describe("Exposed Instructions (@solana/kit)", () => {
   const mockAddress = "11111111111111111111111111111111" as Address;
   const differentAddress = "11111111111111111111111111111112" as Address;
+  const token2022ProgramId = address(
+    "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+  );
   const addressEncoder = getAddressEncoder();
 
   describe("delegate instruction", () => {
@@ -877,6 +882,48 @@ describe("Exposed Instructions (@solana/kit)", () => {
 
       expect(initInstruction).toBeUndefined();
       expect(delegateInstruction).toBeDefined();
+    });
+  });
+
+  describe("undelegateIx (Ephemeral SPL Token Program)", () => {
+    const owner = address("11111111111111111111111111111113");
+    const mint = address("11111111111111111111111111111114");
+
+    it("should use the default SPL Token ATA", async () => {
+      const instruction = await undelegateIx(owner, mint);
+      const [defaultAta] = await getProgramDerivedAddress({
+        programAddress: ASSOCIATED_TOKEN_PROGRAM_ID,
+        seeds: [
+          addressEncoder.encode(owner),
+          addressEncoder.encode(TOKEN_PROGRAM_ID),
+          addressEncoder.encode(mint),
+        ],
+      });
+
+      expect(instruction.accounts?.[1].address).toBe(defaultAta);
+    });
+
+    it("should derive the Token-2022 ATA when a token program override is provided", async () => {
+      const instruction = await undelegateIx(owner, mint, token2022ProgramId);
+      const [defaultAta] = await getProgramDerivedAddress({
+        programAddress: ASSOCIATED_TOKEN_PROGRAM_ID,
+        seeds: [
+          addressEncoder.encode(owner),
+          addressEncoder.encode(TOKEN_PROGRAM_ID),
+          addressEncoder.encode(mint),
+        ],
+      });
+      const [token2022Ata] = await getProgramDerivedAddress({
+        programAddress: ASSOCIATED_TOKEN_PROGRAM_ID,
+        seeds: [
+          addressEncoder.encode(owner),
+          addressEncoder.encode(token2022ProgramId),
+          addressEncoder.encode(mint),
+        ],
+      });
+
+      expect(instruction.accounts?.[1].address).toBe(token2022Ata);
+      expect(instruction.accounts?.[1].address).not.toBe(defaultAta);
     });
   });
 

--- a/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/kit/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -60,13 +60,14 @@ async function getAssociatedTokenAddressSync(
   mint: Address,
   owner: Address,
   allowOwnerOffCurve: boolean = true,
+  tokenProgram: Address = TOKEN_PROGRAM_ID,
 ): Promise<Address> {
   const addressEncoder = getAddressEncoder();
   const [ata] = await getProgramDerivedAddress({
     programAddress: ASSOCIATED_TOKEN_PROGRAM_ID,
     seeds: [
       addressEncoder.encode(owner),
-      addressEncoder.encode(TOKEN_PROGRAM_ID),
+      addressEncoder.encode(tokenProgram),
       addressEncoder.encode(mint),
     ],
   });
@@ -1133,8 +1134,14 @@ export async function withdrawSplIx(
 export async function undelegateIx(
   owner: Address,
   mint: Address,
+  tokenProgram: Address = TOKEN_PROGRAM_ID,
 ): Promise<Instruction> {
-  const userAta = await getAssociatedTokenAddressSync(mint, owner);
+  const userAta = await getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    true,
+    tokenProgram,
+  );
   const [ephemeralAta] = await deriveEphemeralAta(owner, mint);
 
   return {

--- a/ts/web3js/src/__test__/instructions.test.ts
+++ b/ts/web3js/src/__test__/instructions.test.ts
@@ -44,6 +44,7 @@ import {
   processPendingTransferQueueRefillIx,
   schedulePrivateTransferIx,
   transferSpl,
+  undelegateIx,
   undelegateAndCloseShuttleEphemeralAtaIx,
   withdrawSplIx,
   withdrawSpl,
@@ -58,6 +59,7 @@ import {
   PERMISSION_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
   TOKEN_2022_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
 } from "../constants";
 import {
   delegateBufferPdaFromDelegatedAccountAndOwnerProgram,
@@ -943,6 +945,40 @@ describe("Exposed Instructions (web3.js)", () => {
       );
       expect(initShuttleInstruction?.keys[2].isWritable).toBe(true);
       expect(delegateShuttleInstruction?.keys[2].isWritable).toBe(true);
+    });
+  });
+
+  describe("undelegateIx (Ephemeral SPL Token Program)", () => {
+    const owner = new PublicKey("11111111111111111111111111111113");
+    const mint = new PublicKey("11111111111111111111111111111114");
+
+    it("should use the default SPL Token ATA", () => {
+      const instruction = undelegateIx(owner, mint);
+      const [defaultAta] = PublicKey.findProgramAddressSync(
+        [owner.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
+        ASSOCIATED_TOKEN_PROGRAM_ID,
+      );
+
+      expect(instruction.keys[1].pubkey.toBase58()).toBe(defaultAta.toBase58());
+    });
+
+    it("should derive the Token-2022 ATA when a token program override is provided", () => {
+      const instruction = undelegateIx(owner, mint, TOKEN_2022_PROGRAM_ID);
+      const [defaultAta] = PublicKey.findProgramAddressSync(
+        [owner.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
+        ASSOCIATED_TOKEN_PROGRAM_ID,
+      );
+      const [token2022Ata] = PublicKey.findProgramAddressSync(
+        [owner.toBuffer(), TOKEN_2022_PROGRAM_ID.toBuffer(), mint.toBuffer()],
+        ASSOCIATED_TOKEN_PROGRAM_ID,
+      );
+
+      expect(instruction.keys[1].pubkey.toBase58()).toBe(
+        token2022Ata.toBase58(),
+      );
+      expect(instruction.keys[1].pubkey.toBase58()).not.toBe(
+        defaultAta.toBase58(),
+      );
     });
   });
 

--- a/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
+++ b/ts/web3js/src/instructions/ephemeral-spl-token-program/ephemeralAta.ts
@@ -1223,8 +1223,14 @@ export function withdrawSplIx(
 export function undelegateIx(
   owner: PublicKey,
   mint: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
-  const userAta = getAssociatedTokenAddressSync(mint, owner);
+  const userAta = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    true,
+    tokenProgram,
+  );
   const [ephemeralAta] = deriveEphemeralAta(owner, mint);
 
   return new TransactionInstruction({


### PR DESCRIPTION
## Summary
- Add an optional token program override to undelegateIx while keeping TOKEN_PROGRAM_ID as the default
- Derive the undelegate destination ATA with the provided token program
- Add regression coverage for default SPL Token and Token-2022 ATA derivation in both TS SDK surfaces

## Tests
- npm run build (ts/web3js)
- npm run test (ts/web3js)
- npm run build (ts/kit)
- npm run test (ts/kit)

## Notes
- `npm run lint` could not complete locally due to a local path resolution issue.

Closes #234