### PR TITLE
delegate: reject typed Anchor accounts on `del` fields at compile time

### DIFF
--- a/rust/delegate/README.md
+++ b/rust/delegate/README.md
@@ -27,8 +27,9 @@ pub struct DelegatePlayer<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
 
-    #[account(mut, del)]  // <-- delegation marker
-    pub player: Account<'info, PlayerState>,
+    /// CHECK: delegated PDA, validated by seeds
+    #[account(mut, del, seeds = [b"player", payer.key().as_ref()], bump)]  // <-- delegation marker
+    pub player: UncheckedAccount<'info>,
 }
 
 pub fn delegate_player(ctx: Context<DelegatePlayer>) -> Result<()> {
@@ -41,6 +42,12 @@ pub fn delegate_player(ctx: Context<DelegatePlayer>) -> Result<()> {
     Ok(())
 }
 ```
+
+`del` fields must be `UncheckedAccount` or `AccountInfo`; the macro rejects typed accounts
+such as `Account<T>` at compile time. Anchor re-serializes typed accounts after the handler
+returns, when the account is already owned by the delegation program, and that write fails
+under direct mapping (SIMD-0460). To update the account in the same instruction, load it into
+a local typed wrapper, mutate it, and call `.exit(&crate::ID)` on it before delegating.
 
 **Auto-generated fields:**
 - `buffer_player`

--- a/rust/delegate/src/lib.rs
+++ b/rust/delegate/src/lib.rs
@@ -1,8 +1,8 @@
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Delimiter, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, ItemStruct};
+use syn::ItemStruct;
 
 fn generated_unchecked_account_type() -> TokenStream2 {
     if cfg!(feature = "backward-compat") {
@@ -28,9 +28,62 @@ fn is_untyped_anchor_account(ty: &syn::Type) -> bool {
     })
 }
 
+/// Splits `#[account(...)]` into its top-level comma-separated constraints.
+/// Nested groups such as `seeds = [a, b]` stay intact because they are single token trees.
+fn account_constraints(attr: &syn::Attribute) -> Option<Vec<TokenStream2>> {
+    let mut trees = attr.tokens.clone().into_iter();
+    let (Some(TokenTree::Group(group)), None) = (trees.next(), trees.next()) else {
+        return None;
+    };
+    if group.delimiter() != Delimiter::Parenthesis {
+        return None;
+    }
+    let mut constraints = vec![TokenStream2::new()];
+    for tree in group.stream() {
+        match tree {
+            TokenTree::Punct(punct) if punct.as_char() == ',' => {
+                constraints.push(TokenStream2::new());
+            }
+            tree => constraints.last_mut().unwrap().extend(Some(tree)),
+        }
+    }
+    constraints.retain(|constraint| !constraint.is_empty());
+    Some(constraints)
+}
+
+/// A constraint is the `del` marker only when it is exactly that identifier, so
+/// `seeds::program = delegation_program.key()` and the like are never mistaken for it.
+fn is_del_marker(constraint: &TokenStream2) -> bool {
+    let mut trees = constraint.clone().into_iter();
+    matches!(
+        (trees.next(), trees.next()),
+        (Some(TokenTree::Ident(ident)), None) if ident == "del"
+    )
+}
+
+/// Removes the `del` marker from an `#[account(...)]` attribute, reporting whether it was present.
+fn strip_del_marker(attr: &mut syn::Attribute) -> bool {
+    let Some(constraints) = account_constraints(attr) else {
+        return false;
+    };
+    let (del, kept): (Vec<_>, Vec<_>) = constraints.into_iter().partition(is_del_marker);
+    if del.is_empty() {
+        return false;
+    }
+    attr.tokens = quote! { ( #(#kept),* ) };
+    true
+}
+
 #[proc_macro_attribute]
 pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(item as ItemStruct);
+    expand(item.into()).into()
+}
+
+fn expand(item: TokenStream2) -> TokenStream2 {
+    let input = match syn::parse2::<ItemStruct>(item) {
+        Ok(input) => input,
+        Err(err) => return err.to_compile_error(),
+    };
 
     // Extract the struct name and fields
     let struct_name = &input.ident;
@@ -55,15 +108,17 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     field,
                     "Unnamed fields are not supported in this macro",
                 )
-                .to_compile_error()
-                .into();
+                .to_compile_error();
             }
         };
 
-        // Check if the field has the `del` attribute
-        let has_del = field_attrs
-            .iter()
-            .any(|attr| attr.path.is_ident("account") && attr.tokens.to_string().contains("del"));
+        // Check if the field has the `del` marker, dropping it from the emitted attributes
+        let mut has_del = false;
+        for attr in &mut field_attrs {
+            if attr.path.is_ident("account") {
+                has_del |= strip_del_marker(attr);
+            }
+        }
 
         if has_del && !is_untyped_anchor_account(&field.ty) {
             return syn::Error::new_spanned(
@@ -75,8 +130,7 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
                  Load the account into a local typed wrapper (e.g. `Account::<T>::try_from`) \
                  inside the handler and call `.exit(&crate::ID)` on it before delegating.",
             )
-            .to_compile_error()
-            .into();
+            .to_compile_error();
         }
 
         if has_del {
@@ -85,20 +139,6 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 syn::Ident::new(&format!("delegation_record_{field_name}"), field.span());
             let delegation_metadata_field =
                 syn::Ident::new(&format!("delegation_metadata_{field_name}"), field.span());
-
-            // Remove `del` from attributes
-            for attr in &mut field_attrs {
-                if attr.path.is_ident("account") {
-                    let tokens = attr.tokens.to_string();
-                    if tokens.contains("del") {
-                        let new_tokens = tokens
-                            .replace(", del", "")
-                            .replace("del, ", "")
-                            .replace("del", "");
-                        attr.tokens = syn::parse_str(&new_tokens).unwrap();
-                    }
-                }
-            }
 
             // Add new fields
             new_fields.push(quote! {
@@ -205,5 +245,79 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    TokenStream::from(expanded)
+    expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expand_str(item: &str) -> String {
+        expand(item.parse().unwrap()).to_string()
+    }
+
+    #[test]
+    fn del_marker_is_matched_as_whole_constraint() {
+        let attr: syn::Attribute = syn::parse_quote! {
+            #[account(mut, del, seeds = [b"player", payer.key().as_ref()], bump)]
+        };
+        let constraints = account_constraints(&attr).unwrap();
+        assert_eq!(constraints.len(), 4);
+        assert_eq!(constraints.iter().filter(|c| is_del_marker(c)).count(), 1);
+
+        let attr: syn::Attribute = syn::parse_quote! {
+            #[account(mut, seeds::program = delegation_program.key(), bump)]
+        };
+        assert!(!account_constraints(&attr)
+            .unwrap()
+            .iter()
+            .any(is_del_marker));
+    }
+
+    #[test]
+    fn strip_del_marker_keeps_other_constraints() {
+        let mut attr: syn::Attribute = syn::parse_quote! {
+            #[account(mut, del, seeds = [b"player", payer.key().as_ref()], bump)]
+        };
+        assert!(strip_del_marker(&mut attr));
+        assert_eq!(
+            attr.tokens.to_string(),
+            quote! { (mut, seeds = [b"player", payer.key().as_ref()], bump) }.to_string()
+        );
+
+        let mut attr: syn::Attribute = syn::parse_quote! { #[account(del)] };
+        assert!(strip_del_marker(&mut attr));
+        assert_eq!(attr.tokens.to_string(), quote! { () }.to_string());
+    }
+
+    #[test]
+    fn typed_field_referencing_delegation_program_is_not_a_del_field() {
+        let output = expand_str(
+            r#"
+            pub struct Delegate<'info> {
+                #[account(mut, seeds = [b"record"], bump, seeds::program = delegation_program.key())]
+                pub record: Account<'info, Record>,
+                /// CHECK: delegated PDA
+                #[account(mut, del, seeds = [b"player"], bump)]
+                pub player: UncheckedAccount<'info>,
+            }
+            "#,
+        );
+        assert!(!output.contains("compile_error"), "{output}");
+        assert!(output.contains("delegate_player"));
+        assert!(!output.contains("delegate_record"));
+    }
+
+    #[test]
+    fn typed_del_field_is_rejected() {
+        let output = expand_str(
+            r#"
+            pub struct Delegate<'info> {
+                #[account(mut, del)]
+                pub player: Account<'info, Player>,
+            }
+            "#,
+        );
+        assert!(output.contains("compile_error"), "{output}");
+    }
 }

--- a/rust/delegate/src/lib.rs
+++ b/rust/delegate/src/lib.rs
@@ -16,6 +16,8 @@ fn generated_unchecked_account_type() -> TokenStream2 {
 /// account is owned by the delegation program, so that write fails with
 /// `ExternalAccountDataModified` once direct mapping (SIMD-0460) is active.
 /// Only `UncheckedAccount` and `AccountInfo` are exempt from that exit.
+/// This is a syntactic guard: a proc macro cannot resolve type aliases, so it catches the
+/// common mistake rather than a deliberate alias that shadows one of those names.
 fn is_untyped_anchor_account(ty: &syn::Type) -> bool {
     let syn::Type::Path(path) = ty else {
         return false;
@@ -38,15 +40,17 @@ fn account_constraints(attr: &syn::Attribute) -> Option<Vec<TokenStream2>> {
     if group.delimiter() != Delimiter::Parenthesis {
         return None;
     }
-    let mut constraints = vec![TokenStream2::new()];
+    let mut constraints = Vec::new();
+    let mut current = TokenStream2::new();
     for tree in group.stream() {
         match tree {
             TokenTree::Punct(punct) if punct.as_char() == ',' => {
-                constraints.push(TokenStream2::new());
+                constraints.push(std::mem::take(&mut current));
             }
-            tree => constraints.last_mut().unwrap().extend(Some(tree)),
+            tree => current.extend(Some(tree)),
         }
     }
+    constraints.push(current);
     constraints.retain(|constraint| !constraint.is_empty());
     Some(constraints)
 }

--- a/rust/delegate/src/lib.rs
+++ b/rust/delegate/src/lib.rs
@@ -12,6 +12,22 @@ fn generated_unchecked_account_type() -> TokenStream2 {
     }
 }
 
+/// Anchor re-serializes typed accounts after the handler returns. By then a delegated
+/// account is owned by the delegation program, so that write fails with
+/// `ExternalAccountDataModified` once direct mapping (SIMD-0460) is active.
+/// Only `UncheckedAccount` and `AccountInfo` are exempt from that exit.
+fn is_untyped_anchor_account(ty: &syn::Type) -> bool {
+    let syn::Type::Path(path) = ty else {
+        return false;
+    };
+    path.path.segments.last().is_some_and(|segment| {
+        matches!(
+            segment.ident.to_string().as_str(),
+            "UncheckedAccount" | "AccountInfo"
+        )
+    })
+}
+
 #[proc_macro_attribute]
 pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemStruct);
@@ -48,6 +64,20 @@ pub fn delegate(_attr: TokenStream, item: TokenStream) -> TokenStream {
         let has_del = field_attrs
             .iter()
             .any(|attr| attr.path.is_ident("account") && attr.tokens.to_string().contains("del"));
+
+        if has_del && !is_untyped_anchor_account(&field.ty) {
+            return syn::Error::new_spanned(
+                &field.ty,
+                "`del` accounts must be `UncheckedAccount<'info>` or `AccountInfo<'info>`. \
+                 Anchor re-serializes typed accounts after the handler returns, but by then the \
+                 account is owned by the delegation program, so the write fails with \
+                 ExternalAccountDataModified once direct mapping (SIMD-0460) is active. \
+                 Load the account into a local typed wrapper (e.g. `Account::<T>::try_from`) \
+                 inside the handler and call `.exit(&crate::ID)` on it before delegating.",
+            )
+            .to_compile_error()
+            .into();
+        }
 
         if has_del {
             let buffer_field = syn::Ident::new(&format!("buffer_{field_name}"), field.span());


### PR DESCRIPTION
## Problem

Anchor's generated `AccountsExit` re-serializes every `mut` typed account after the handler returns. A `del` field is owned by the delegation program by then, so that write targets an account the program no longer owns.

Before direct mapping this was a silent no-op: the bytes matched what the delegation program had already written, and the loader only errors on a non-owned account when the bytes differ. With SIMD-0460 (`7VgiehxNxu53KdxgLspGQY8myE6f7UokaWa4jsGcaSz`, live on devnet, pending mainnet) the account region is mapped read-only after the CPI and the store fails immediately with `ExternalAccountDataModified`.

## Change

- `#[delegate]` now emits a compile error unless the `del` field is `UncheckedAccount` or `AccountInfo`. The message explains why and how to fix it (load a local typed wrapper, call `.exit(&crate::ID)`, then delegate).
- Allowlist rather than denylist, so `Account`, `Box<Account>`, `AccountLoader`, `InterfaceAccount`, `LazyAccount`, `Migration` and any alias are all rejected. Anchor forbids segmented type paths in `#[derive(Accounts)]`, so matching on the last path segment is sufficient.
- The crate README example used `Account<T>` on a `del` field and is updated.

## Verification

- `cargo fmt --check` and `cargo clippy -- --deny=warnings` clean on the workspace.
- Scratch crate against this branch: `UncheckedAccount` and `AccountInfo` fields compile; `Account<T>`, `Box<Account<T>>` and `Migration<..>` fail with the new error.

## Notes

This is a breaking change for anyone still using a typed account on a `del` field; those programs will start failing on mainnet at feature activation regardless. Worth a minor version bump. A companion fix making Anchor's exit skip accounts no longer owned by the program is prepared separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent delegation from using typed accounts that cannot be safely written after the handler completes.
  * Improved compile-time error messages with guidance for updating account data before delegation.
  * Improved handling of delegation account constraints and markers for more reliable validation.

* **Documentation**
  * Updated usage examples to use unchecked account types with explicit seed and bump constraints.
  * Added guidance for safely modifying account data within the same instruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->